### PR TITLE
Implements RunProcessTask

### DIFF
--- a/eawx-build-test/Core/JobTest.cs
+++ b/eawx-build-test/Core/JobTest.cs
@@ -26,41 +26,8 @@ namespace EawXBuildTest.Core {
             AssertTaskWasRun(secondTask);
         }
 
-        [TestMethod]
-        public void GivenJobWithTaskThatThrowsException__WhenRunningJob__ShouldPrintExceptionMessageToStdOut() {
-            var stringBuilder = new StringBuilder();
-            var stringWriter = new StringWriter(stringBuilder, CultureInfo.InvariantCulture);
-            Console.SetOut(stringWriter);
-
-            var sut = new Job("job");
-            const string exceptionMessage = "exception message";
-            sut.AddTask(new ExceptionThrowingTask(exceptionMessage));
-
-            sut.Run();
-
-            const string expectedOutput = "exception message\n";
-            Assert.AreEqual(expectedOutput, stringBuilder.ToString());
-        }
-
-        [TestMethod]
-        public void GivenJobWithTaskThatThrowsException_AndSecondTask__WhenRunningJob__ShouldNotRunSecondTask() {
-            var taskSpy = new TaskSpy();
-
-            var sut = new Job("job");
-            sut.AddTask(new ExceptionThrowingTask());
-            sut.AddTask(taskSpy);
-
-            sut.Run();
-
-            AssertTaskWasNotRun(taskSpy);
-        }
-
         private static void AssertTaskWasRun(TaskSpy firstTask) {
             Assert.IsTrue(firstTask.WasRun, "Task should have been run, but wasn't.");
-        }
-
-        private static void AssertTaskWasNotRun(TaskSpy taskSpy) {
-            Assert.IsFalse(taskSpy.WasRun, "Should not have run task, but did");
         }
     }
 }

--- a/eawx-build-test/Core/JobTest.cs
+++ b/eawx-build-test/Core/JobTest.cs
@@ -1,15 +1,20 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Text;
+using EawXBuild.Core;
+using EawXBuildTest.Tasks;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Core
-{
+namespace EawXBuildTest.Core {
     [TestClass]
-    public class JobTest
-    {
+    public class JobTest {
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
-        public void GivenJobWithTwoTasks__WhenRunningJob__ShouldExecuteAllTasks()
-        {
-            var sut = new EawXBuild.Core.Job("job");
+        public void GivenJobWithTwoTasks__WhenRunningJob__ShouldExecuteAllTasks() {
+            var sut = new Job("job");
             var firstTask = new TaskSpy();
             var secondTask = new TaskSpy();
             sut.AddTask(firstTask);
@@ -21,9 +26,41 @@ namespace EawXBuildTest.Core
             AssertTaskWasRun(secondTask);
         }
 
-        private static void AssertTaskWasRun(TaskSpy firstTask)
-        {
+        [TestMethod]
+        public void GivenJobWithTaskThatThrowsException__WhenRunningJob__ShouldPrintExceptionMessageToStdOut() {
+            var stringBuilder = new StringBuilder();
+            var stringWriter = new StringWriter(stringBuilder, CultureInfo.InvariantCulture);
+            Console.SetOut(stringWriter);
+
+            var sut = new Job("job");
+            const string exceptionMessage = "exception message";
+            sut.AddTask(new ExceptionThrowingTask(exceptionMessage));
+
+            sut.Run();
+
+            const string expectedOutput = "exception message\n";
+            Assert.AreEqual(expectedOutput, stringBuilder.ToString());
+        }
+
+        [TestMethod]
+        public void GivenJobWithTaskThatThrowsException_AndSecondTask__WhenRunningJob__ShouldNotRunSecondTask() {
+            var taskSpy = new TaskSpy();
+
+            var sut = new Job("job");
+            sut.AddTask(new ExceptionThrowingTask());
+            sut.AddTask(taskSpy);
+
+            sut.Run();
+
+            AssertTaskWasNotRun(taskSpy);
+        }
+
+        private static void AssertTaskWasRun(TaskSpy firstTask) {
             Assert.IsTrue(firstTask.WasRun, "Task should have been run, but wasn't.");
+        }
+
+        private static void AssertTaskWasNotRun(TaskSpy taskSpy) {
+            Assert.IsFalse(taskSpy.WasRun, "Should not have run task, but did");
         }
     }
 }

--- a/eawx-build-test/Core/JobTestDoubles.cs
+++ b/eawx-build-test/Core/JobTestDoubles.cs
@@ -1,40 +1,45 @@
+using System;
 using System.Collections.Generic;
 using EawXBuild.Core;
 
-namespace EawXBuildTest.Core
-{
-    public class JobDummy : IJob
-    {
+namespace EawXBuildTest.Core {
+    public class JobDummy : IJob {
         public virtual string Name { get; set; }
 
-        public virtual void AddTask(ITask task)
-        {
+        public virtual void AddTask(ITask task) {
         }
 
-        public virtual void Run()
-        {
+        public virtual void Run() {
         }
     }
 
-    public class JobStub : JobDummy
-    {
+    public class JobStub : JobDummy {
         public List<ITask> Tasks { get; } = new List<ITask>();
 
         public override string Name { get; set; }
 
-        public override void AddTask(ITask task)
-        {
+        public override void AddTask(ITask task) {
             Tasks.Add(task);
         }
     }
 
-    public class JobSpy : JobStub
-    {
+    public class JobSpy : JobStub {
         public bool WasRun { get; private set; }
 
-        public override void Run()
-        {
+        public override void Run() {
             WasRun = true;
+        }
+    }
+
+    public class ExceptionThrowingJob : JobDummy {
+        private readonly string _exceptionMessage;
+
+        public ExceptionThrowingJob(string exceptionMessage) {
+            _exceptionMessage = exceptionMessage;
+        }
+
+        public override void Run() {
+            throw new Exception(_exceptionMessage);
         }
     }
 }

--- a/eawx-build-test/Core/ProjectTest.cs
+++ b/eawx-build-test/Core/ProjectTest.cs
@@ -1,23 +1,24 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using EawXBuild.Core;
 using EawXBuild.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Core
-{
+namespace EawXBuildTest.Core {
     [TestClass]
-    public class ProjectTest
-    {
-        private EawXBuild.Core.Project _sut;
+    public class ProjectTest {
+        private Project _sut;
 
         [TestInitialize]
-        public void SetUp()
-        {
-            _sut = new EawXBuild.Core.Project();
+        public void SetUp() {
+            _sut = new Project();
         }
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
-        public async System.Threading.Tasks.Task GivenProjectWithNamedJob__WhenCallingRunWithJobName__ShouldRunJob()
-        {
+        public async System.Threading.Tasks.Task GivenProjectWithNamedJob__WhenCallingRunWithJobName__ShouldRunJob() {
             var jobSpy = MakeJobSpy("job");
             _sut.AddJob(jobSpy);
 
@@ -29,8 +30,7 @@ namespace EawXBuildTest.Core
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
         public async System.Threading.Tasks.Task
-            GivenProjectWithTwoJobs__WhenCallingRunWithJobName__ShouldOnlyRunWithMatchingName()
-        {
+            GivenProjectWithTwoJobs__WhenCallingRunWithJobName__ShouldOnlyRunWithMatchingName() {
             var otherJob = MakeJobSpy("other");
             _sut.AddJob(otherJob);
             var expected = MakeJobSpy("job");
@@ -46,16 +46,14 @@ namespace EawXBuildTest.Core
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
         [ExpectedException(typeof(JobNotFoundException))]
-        public void GivenProjectWithNoJobs__WhenCallingRunJob__ShouldThrowJobNotFoundException()
-        {
+        public void GivenProjectWithNoJobs__WhenCallingRunJob__ShouldThrowJobNotFoundException() {
             _sut.RunJobAsync("job");
         }
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
         [ExpectedException(typeof(DuplicateJobNameException))]
-        public void GivenProjectWithJob__WhenAddingJobWithSameName__ShouldThrowDuplicateJobNameException()
-        {
+        public void GivenProjectWithJob__WhenAddingJobWithSameName__ShouldThrowDuplicateJobNameException() {
             var jobSpy = MakeJobSpy("job");
 
             Assert.IsNotNull(_sut != null, nameof(_sut) + " != null");
@@ -63,24 +61,34 @@ namespace EawXBuildTest.Core
             _sut.AddJob(MakeJobSpy("job"));
         }
 
-        private static JobSpy MakeJobSpy(string name)
-        {
-            var jobSpy = new JobSpy
-            {
-                Name = name
-            };
+        [TestMethod]
+        [TestCategory(TestUtility.TEST_TYPE_HOLY)]
+        public async System.Threading.Tasks.Task GivenProjectWithJobThatThrowsException__WhenRunningJob__ShouldPrintException() {
+            var stringBuilder = new StringBuilder();
+            var stringWriter = new StringWriter(stringBuilder, CultureInfo.InvariantCulture);
+            Console.SetOut(stringWriter);
+
+
+            const string exceptionMessage = "exception message";
+            _sut.AddJob(new ExceptionThrowingJob(exceptionMessage) {Name = "job"});
+            await _sut.RunJobAsync("job");
+
+            const string expectedOutput = "exception message\n";
+            Assert.AreEqual(expectedOutput, stringBuilder.ToString());
+        }
+
+        private static JobSpy MakeJobSpy(string name) {
+            var jobSpy = new JobSpy {Name = name};
 
             return jobSpy;
         }
 
-        private static void AssertJobWasRun(JobSpy jobSpy)
-        {
+        private static void AssertJobWasRun(JobSpy jobSpy) {
             Assert.IsNotNull(jobSpy != null, nameof(jobSpy) + " != null");
             Assert.IsTrue(jobSpy.WasRun, $"Job {jobSpy.Name} should have been run, but wasn't.");
         }
 
-        private static void AssertJobWasNotRun(JobSpy otherJob)
-        {
+        private static void AssertJobWasNotRun(JobSpy otherJob) {
             Assert.IsNotNull(otherJob != null, nameof(otherJob) + " != null");
             Assert.IsFalse(otherJob.WasRun, $"Should not have run Job {otherJob.Name}, but did.");
         }

--- a/eawx-build-test/Core/ProjectTest.cs
+++ b/eawx-build-test/Core/ProjectTest.cs
@@ -61,22 +61,6 @@ namespace EawXBuildTest.Core {
             _sut.AddJob(MakeJobSpy("job"));
         }
 
-        [TestMethod]
-        [TestCategory(TestUtility.TEST_TYPE_HOLY)]
-        public async System.Threading.Tasks.Task GivenProjectWithJobThatThrowsException__WhenRunningJob__ShouldPrintException() {
-            var stringBuilder = new StringBuilder();
-            var stringWriter = new StringWriter(stringBuilder, CultureInfo.InvariantCulture);
-            Console.SetOut(stringWriter);
-
-
-            const string exceptionMessage = "exception message";
-            _sut.AddJob(new ExceptionThrowingJob(exceptionMessage) {Name = "job"});
-            await _sut.RunJobAsync("job");
-
-            const string expectedOutput = "exception message\n";
-            Assert.AreEqual(expectedOutput, stringBuilder.ToString());
-        }
-
         private static JobSpy MakeJobSpy(string name) {
             var jobSpy = new JobSpy {Name = name};
 

--- a/eawx-build-test/Core/TaskTestDoubles.cs
+++ b/eawx-build-test/Core/TaskTestDoubles.cs
@@ -1,3 +1,4 @@
+using System;
 using EawXBuild.Core;
 
 namespace EawXBuildTest.Core
@@ -16,6 +17,18 @@ namespace EawXBuildTest.Core
         public override void Run()
         {
             WasRun = true;
+        }
+    }
+    
+    public class ExceptionThrowingTask : ITask {
+        private readonly string _message;
+
+        public ExceptionThrowingTask(string message = null) {
+            _message = message;
+        }
+        
+        public void Run() {
+            throw new Exception(_message);
         }
     }
 }

--- a/eawx-build-test/Core/TaskTestDoubles.cs
+++ b/eawx-build-test/Core/TaskTestDoubles.cs
@@ -1,34 +1,16 @@
-using System;
 using EawXBuild.Core;
 
-namespace EawXBuildTest.Core
-{
-    public class TaskDummy : ITask
-    {
-        public virtual void Run()
-        {
+namespace EawXBuildTest.Core {
+    public class TaskDummy : ITask {
+        public virtual void Run() {
         }
     }
 
-    public class TaskSpy : TaskDummy
-    {
+    public class TaskSpy : TaskDummy {
         public bool WasRun { get; private set; }
 
-        public override void Run()
-        {
+        public override void Run() {
             WasRun = true;
-        }
-    }
-    
-    public class ExceptionThrowingTask : ITask {
-        private readonly string _message;
-
-        public ExceptionThrowingTask(string message = null) {
-            _message = message;
-        }
-        
-        public void Run() {
-            throw new Exception(_message);
         }
     }
 }

--- a/eawx-build-test/Services/Process/ProcessRunnerTestDoubles.cs
+++ b/eawx-build-test/Services/Process/ProcessRunnerTestDoubles.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using EawXBuild.Services.Process;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/eawx-build-test/Services/Process/ProcessRunnerTestDoubles.cs
+++ b/eawx-build-test/Services/Process/ProcessRunnerTestDoubles.cs
@@ -12,6 +12,13 @@ namespace EawXBuildTest.Services.Process {
 
         public virtual void WaitForExit() {
         }
+
+        public virtual int ExitCode { get; set; }
+    }
+
+    public class ProcessRunnerStub : ProcessRunnerDummy {
+
+        public override int ExitCode { get; set; }
     }
 
     public class ProcessRunnerSpy : ProcessRunnerDummy {
@@ -48,8 +55,16 @@ namespace EawXBuildTest.Services.Process {
             base.WaitForExit();
         }
 
+        public override int ExitCode {
+            get {
+                _callOrder += "e";
+                return 0;
+            }
+            set {}
+        }
+
         public void Verify() {
-            const string expected = "sw";
+            const string expected = "swe";
             Assert.AreEqual(expected, _callOrder);
         }
     }

--- a/eawx-build-test/Services/Process/ProcessRunnerTestDoubles.cs
+++ b/eawx-build-test/Services/Process/ProcessRunnerTestDoubles.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using EawXBuild.Services.Process;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EawXBuildTest.Services.Process {
+    public class ProcessRunnerDummy : IProcessRunner {
+        public virtual void Start(string executablePath) {
+        }
+
+        public virtual void Start(string executablePath, string arguments) {
+        }
+
+        public virtual void WaitForExit() {
+        }
+    }
+
+    public class ProcessRunnerSpy : ProcessRunnerDummy {
+        public bool WasStarted { get; private set; }
+
+        public string ExecutablePath { get; private set; }
+        
+        public string Arguments { get; private set; }
+
+        public override void Start(string executablePath) {
+            WasStarted = true;
+            ExecutablePath = executablePath;
+        }
+        
+        public override void Start(string executablePath, string arguments) {
+            Start(executablePath);
+            Arguments = arguments;
+        }
+
+        public override void WaitForExit() {
+        }
+    }
+
+    public class CallOrderVerifyingProcessRunnerMock : ProcessRunnerSpy {
+        private string _callOrder = "";
+
+        public override void Start(string executablePath) {
+            _callOrder += "s";
+            base.Start(executablePath);
+        }
+
+        public override void WaitForExit() {
+            _callOrder += "w";
+            base.WaitForExit();
+        }
+
+        public void Verify() {
+            const string expected = "sw";
+            Assert.AreEqual(expected, _callOrder);
+        }
+    }
+}

--- a/eawx-build-test/Tasks/FileSystemAssertions.cs
+++ b/eawx-build-test/Tasks/FileSystemAssertions.cs
@@ -25,7 +25,7 @@ namespace EawXBuildTest.Tasks
         
         public void AssertFileExists(string expected)
         {
-            Assert.IsTrue(_fileSystem.FileExists(expected), $"File {expected} should exist, but doesn'nt");
+            Assert.IsTrue(_fileSystem.FileExists(expected), $"File {expected} should exist, but doesn't");
         }
 
         public void AssertFileDoesNotExist(string filePath)

--- a/eawx-build-test/Tasks/RunProcessTaskTest.cs
+++ b/eawx-build-test/Tasks/RunProcessTaskTest.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using EawXBuild.Exceptions;
+using EawXBuild.Services.Process;
 using EawXBuild.Tasks;
 using EawXBuildTest.Services.Process;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -36,7 +39,7 @@ namespace EawXBuildTest.Tasks {
             _sut.Arguments = arguments;
 
             _sut.Run();
-            
+
             Assert.AreEqual(arguments, _runner.Arguments);
         }
 
@@ -44,13 +47,14 @@ namespace EawXBuildTest.Tasks {
         [ExpectedException(typeof(ProcessFailedException))]
         public void GivenExecutableThatExitsWithCodeOne__WhenCallingRun__ShouldThrowProcessFailedException() {
             var runner = new ProcessRunnerStub {ExitCode = 1};
-            var sut = new RunProcessTask(runner, _filesystem) { ExecutablePath = _executablePath };
+            var sut = new RunProcessTask(runner, _filesystem) {ExecutablePath = _executablePath};
 
             sut.Run();
         }
-        
+
         [TestMethod]
-        public void GivenPathToExecutable__WhenCallingRun__ShouldCallStartFirst_Then_BlockUntilFinished_Then_CheckExitCode() {
+        public void
+            GivenPathToExecutable__WhenCallingRun__ShouldCallStartFirst_Then_BlockUntilFinished_Then_CheckExitCode() {
             var runner = new CallOrderVerifyingProcessRunnerMock();
 
             const string executablePath = "myProgram.exe";
@@ -59,16 +63,6 @@ namespace EawXBuildTest.Tasks {
             sut.Run();
 
             runner.Verify();
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(FileNotFoundException))]
-        public void GivenPathToNonExistingExecutable__WhenCallingRun__ShouldThrowFileNotFoundException() {
-            var sut = new RunProcessTask(new ProcessRunnerDummy(), _filesystem) {
-                ExecutablePath = "NonExistingProgram.exe"
-            };
-
-            sut.Run();
         }
 
         private static void AssertProcessWasStartedWithExecutable(ProcessRunnerSpy runner, string executablePath) {

--- a/eawx-build-test/Tasks/RunProcessTaskTest.cs
+++ b/eawx-build-test/Tasks/RunProcessTaskTest.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using EawXBuild.Tasks;
+using EawXBuildTest.Services.Process;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EawXBuildTest.Tasks {
+    [TestClass]
+    public class RunProcessTaskTest {
+        private RunProcessTask _sut;
+        private ProcessRunnerSpy _runner;
+        private MockFileSystem _filesystem;
+        private string _executablePath;
+
+        [TestInitialize]
+        public void Setup() {
+            _runner = new ProcessRunnerSpy();
+            _filesystem = new MockFileSystem();
+            _filesystem.AddFile("myProgram.exe", new MockFileData(string.Empty));
+            _executablePath = "myProgram.exe";
+            _sut = new RunProcessTask(_runner, _filesystem) {ExecutablePath = _executablePath};
+        }
+
+        [TestMethod]
+        public void GivenPathToExecutable__WhenCallingRun__ShouldStartProcess() {
+            _sut.Run();
+
+            AssertProcessWasStartedWithExecutable(_runner, _executablePath);
+        }
+
+        [TestMethod]
+        public void GivenPathToExecutable__WhenCallingRun__ShouldCallStartFirst_Then_BlockUntilFinished() {
+            var runner = new CallOrderVerifyingProcessRunnerMock();
+
+            const string executablePath = "myProgram.exe";
+            RunProcessTask sut = new RunProcessTask(runner, _filesystem) {ExecutablePath = executablePath};
+
+            sut.Run();
+
+            runner.Verify();
+        }
+
+        [TestMethod]
+        public void GivenExecutablePathAndArguments__WhenCallingRun__ShouldStartProcessWithArguments() {
+            var arguments = "--first --second --third";
+            _sut.Arguments = arguments;
+
+            _sut.Run();
+            
+            Assert.AreEqual(arguments, _runner.Arguments);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void GivenPathToNonExistingExecutable__WhenCallingRun__ShouldThrowFileNotFoundException() {
+            var sut = new RunProcessTask(new ProcessRunnerDummy(), _filesystem) {
+                ExecutablePath = "NonExistingProgram.exe"
+            };
+
+            sut.Run();
+        }
+
+        private static void AssertProcessWasStartedWithExecutable(ProcessRunnerSpy runner, string executablePath) {
+            Assert.IsTrue(runner.WasStarted, "Should have called Start(), but didn't");
+            Assert.AreEqual(executablePath, runner.ExecutablePath,
+                $"Should have called Start() with {executablePath}, but was {runner.ExecutablePath}");
+        }
+    }
+}

--- a/eawx-build-test/Tasks/RunProcessTaskTest.cs
+++ b/eawx-build-test/Tasks/RunProcessTaskTest.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Diagnostics;
-using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using EawXBuild.Exceptions;
-using EawXBuild.Services.Process;
 using EawXBuild.Tasks;
 using EawXBuildTest.Services.Process;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/eawx-build-test/Tasks/RunProcessTaskTest.cs
+++ b/eawx-build-test/Tasks/RunProcessTaskTest.cs
@@ -1,6 +1,6 @@
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
+using EawXBuild.Exceptions;
 using EawXBuild.Tasks;
 using EawXBuildTest.Services.Process;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -29,8 +29,28 @@ namespace EawXBuildTest.Tasks {
             AssertProcessWasStartedWithExecutable(_runner, _executablePath);
         }
 
+
         [TestMethod]
-        public void GivenPathToExecutable__WhenCallingRun__ShouldCallStartFirst_Then_BlockUntilFinished() {
+        public void GivenExecutablePathAndArguments__WhenCallingRun__ShouldStartProcessWithArguments() {
+            const string arguments = "--first --second --third";
+            _sut.Arguments = arguments;
+
+            _sut.Run();
+            
+            Assert.AreEqual(arguments, _runner.Arguments);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ProcessFailedException))]
+        public void GivenExecutableThatExitsWithCodeOne__WhenCallingRun__ShouldThrowProcessFailedException() {
+            var runner = new ProcessRunnerStub {ExitCode = 1};
+            var sut = new RunProcessTask(runner, _filesystem) { ExecutablePath = _executablePath };
+
+            sut.Run();
+        }
+        
+        [TestMethod]
+        public void GivenPathToExecutable__WhenCallingRun__ShouldCallStartFirst_Then_BlockUntilFinished_Then_CheckExitCode() {
             var runner = new CallOrderVerifyingProcessRunnerMock();
 
             const string executablePath = "myProgram.exe";
@@ -39,16 +59,6 @@ namespace EawXBuildTest.Tasks {
             sut.Run();
 
             runner.Verify();
-        }
-
-        [TestMethod]
-        public void GivenExecutablePathAndArguments__WhenCallingRun__ShouldStartProcessWithArguments() {
-            var arguments = "--first --second --third";
-            _sut.Arguments = arguments;
-
-            _sut.Run();
-            
-            Assert.AreEqual(arguments, _runner.Arguments);
         }
 
         [TestMethod]

--- a/eawx-build-test/Tasks/RunProcessTaskTest.cs
+++ b/eawx-build-test/Tasks/RunProcessTaskTest.cs
@@ -65,6 +65,21 @@ namespace EawXBuildTest.Tasks {
             runner.Verify();
         }
 
+        [TestMethod]
+        [ExpectedException(typeof(NoRelativePathException))]
+        public void GivenAbsolutePath__WhenCallingRun__ShouldThrowNoRelativePathException() {
+            _sut.ExecutablePath = "/absolute/path";
+
+            _sut.Run();
+        }
+        
+        [TestMethod]
+        public void GivenAbsolutePath__WhenCallingRun__ShouldNotStartProcess() {
+            _sut.ExecutablePath = "/absolute/path";
+            Assert.ThrowsException<NoRelativePathException>(() => _sut.Run());
+            Assert.IsFalse(_runner.WasStarted);
+        }
+
         private static void AssertProcessWasStartedWithExecutable(ProcessRunnerSpy runner, string executablePath) {
             Assert.IsTrue(runner.WasStarted, "Should have called Start(), but didn't");
             Assert.AreEqual(executablePath, runner.ExecutablePath,

--- a/eawx-build/Core/Job.cs
+++ b/eawx-build/Core/Job.cs
@@ -12,11 +12,7 @@ namespace EawXBuild.Core {
         public string Name { get; }
 
         public void Run() {
-            try {
-                foreach (var task in _tasks) task.Run();
-            } catch (Exception ex) {
-                Console.Out.WriteLine(ex.Message);
-            }
+            foreach (var task in _tasks) task.Run();
         }
 
         public void AddTask(ITask task) {

--- a/eawx-build/Core/Job.cs
+++ b/eawx-build/Core/Job.cs
@@ -13,8 +13,7 @@ namespace EawXBuild.Core {
 
         public void Run() {
             try {
-                foreach (var task in _tasks)
-                    task.Run();
+                foreach (var task in _tasks) task.Run();
             } catch (Exception ex) {
                 Console.Out.WriteLine(ex.Message);
             }

--- a/eawx-build/Core/Job.cs
+++ b/eawx-build/Core/Job.cs
@@ -1,26 +1,26 @@
+using System;
 using System.Collections.Generic;
 
-namespace EawXBuild.Core
-{
-    public class Job : IJob
-    {
+namespace EawXBuild.Core {
+    public class Job : IJob {
         private readonly List<ITask> _tasks = new List<ITask>();
 
-        public Job(string name)
-        {
+        public Job(string name) {
             Name = name;
         }
 
         public string Name { get; }
 
-        public void Run()
-        {
-            foreach (var task in _tasks)
-                task.Run();
+        public void Run() {
+            try {
+                foreach (var task in _tasks)
+                    task.Run();
+            } catch (Exception ex) {
+                Console.Out.WriteLine(ex.Message);
+            }
         }
 
-        public void AddTask(ITask task)
-        {
+        public void AddTask(ITask task) {
             _tasks.Add(task);
         }
     }

--- a/eawx-build/Core/Project.cs
+++ b/eawx-build/Core/Project.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using EawXBuild.Exceptions;
 
@@ -20,17 +19,7 @@ namespace EawXBuild.Core {
             if (job == null)
                 throw new JobNotFoundException(jobName);
 
-            return System.Threading.Tasks.Task.Run(RunTaskAction(job));
-        }
-
-        private static Action RunTaskAction(IJob job) {
-            return () => {
-                try {
-                    job.Run();
-                } catch (Exception ex) {
-                    Console.WriteLine(ex.Message);
-                }
-            };
+            return System.Threading.Tasks.Task.Run(() => job.Run());
         }
 
         private IJob FindJobWithName(string jobName) {

--- a/eawx-build/Core/Project.cs
+++ b/eawx-build/Core/Project.cs
@@ -1,39 +1,43 @@
+using System;
 using System.Collections.Generic;
 using EawXBuild.Exceptions;
 
-namespace EawXBuild.Core
-{
-    public class Project : IProject
-
-    {
+namespace EawXBuild.Core {
+    public class Project : IProject {
         private readonly List<IJob> jobs = new List<IJob>();
 
         public string Name { get; set; }
 
-        public void AddJob(IJob job)
-        {
+        public void AddJob(IJob job) {
             if (HasJobWithName(job.Name))
                 throw new DuplicateJobNameException(job.Name);
 
             jobs.Add(job);
         }
 
-        public System.Threading.Tasks.Task RunJobAsync(string jobName)
-        {
+        public System.Threading.Tasks.Task RunJobAsync(string jobName) {
             var job = FindJobWithName(jobName);
             if (job == null)
                 throw new JobNotFoundException(jobName);
 
-            return System.Threading.Tasks.Task.Run(() => job.Run());
+            return System.Threading.Tasks.Task.Run(RunTaskAction(job));
         }
 
-        private IJob FindJobWithName(string jobName)
-        {
+        private static Action RunTaskAction(IJob job) {
+            return () => {
+                try {
+                    job.Run();
+                } catch (Exception ex) {
+                    Console.WriteLine(ex.Message);
+                }
+            };
+        }
+
+        private IJob FindJobWithName(string jobName) {
             return jobs.Find(job => job.Name.Equals(jobName));
         }
 
-        private bool HasJobWithName(string jobName)
-        {
+        private bool HasJobWithName(string jobName) {
             return jobs.Exists(j => j.Name.Equals(jobName));
         }
     }

--- a/eawx-build/Exceptions/DuplicateJobNameException.cs
+++ b/eawx-build/Exceptions/DuplicateJobNameException.cs
@@ -1,12 +1,9 @@
 using System;
 
-namespace EawXBuild.Exceptions
-{
+namespace EawXBuild.Exceptions {
     [Serializable]
-    public class DuplicateJobNameException : Exception
-    {
-        public DuplicateJobNameException(string jobName) : base($"Duplicate Job {jobName}")
-        {
+    public class DuplicateJobNameException : Exception {
+        public DuplicateJobNameException(string jobName) : base($"Duplicate Job {jobName}") {
         }
     }
 }

--- a/eawx-build/Exceptions/JobNotFoundException.cs
+++ b/eawx-build/Exceptions/JobNotFoundException.cs
@@ -1,12 +1,9 @@
 using System;
 
-namespace EawXBuild.Exceptions
-{
+namespace EawXBuild.Exceptions {
     [Serializable]
-    public class JobNotFoundException : Exception
-    {
-        public JobNotFoundException(string jobName) : base($"No Job with name {jobName}")
-        {
+    public class JobNotFoundException : Exception {
+        public JobNotFoundException(string jobName) : base($"No Job with name {jobName}") {
         }
     }
 }

--- a/eawx-build/Exceptions/NoSuchFileSystemObjectException.cs
+++ b/eawx-build/Exceptions/NoSuchFileSystemObjectException.cs
@@ -1,13 +1,10 @@
 using System;
 
-namespace EawXBuild.Exceptions
-{
+namespace EawXBuild.Exceptions {
     [Serializable]
-    public class NoSuchFileSystemObjectException : Exception
-    {
+    public class NoSuchFileSystemObjectException : Exception {
         public NoSuchFileSystemObjectException(string fileSystemObjectName) : base(
-            $"No such file or directory: {fileSystemObjectName}")
-        {
+            $"No such file or directory: {fileSystemObjectName}") {
         }
     }
 }

--- a/eawx-build/Exceptions/ProcessFailedException.cs
+++ b/eawx-build/Exceptions/ProcessFailedException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace EawXBuild.Exceptions {
+    public class ProcessFailedException : Exception {
+        public ProcessFailedException(string message = null) : base(message) {
+        }
+    }
+}

--- a/eawx-build/Services/Process/IProcessRunner.cs
+++ b/eawx-build/Services/Process/IProcessRunner.cs
@@ -6,5 +6,7 @@ namespace EawXBuild.Services.Process {
         void Start(string executablePath, string arguments);
 
         void WaitForExit();
+
+        int ExitCode { get; }
     }
 }

--- a/eawx-build/Services/Process/IProcessRunner.cs
+++ b/eawx-build/Services/Process/IProcessRunner.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace EawXBuild.Services.Process {
+    public interface IProcessRunner {
+        void Start(string executablePath);
+        void Start(string executablePath, string arguments);
+
+        void WaitForExit();
+    }
+}

--- a/eawx-build/Services/Process/ProcessRunner.cs
+++ b/eawx-build/Services/Process/ProcessRunner.cs
@@ -25,7 +25,7 @@ namespace EawXBuild.Services.Process {
             };
 
             _process.Start();
-            Console.WriteLine(_process.StandardOutput.ReadToEnd());
+            Console.Out.WriteLine(_process.StandardOutput.ReadToEnd());
         }
 
         public void WaitForExit() {

--- a/eawx-build/Services/Process/ProcessRunner.cs
+++ b/eawx-build/Services/Process/ProcessRunner.cs
@@ -31,5 +31,7 @@ namespace EawXBuild.Services.Process {
         public void WaitForExit() {
             _process.WaitForExit();
         }
+
+        public int ExitCode => _process.ExitCode;
     }
 }

--- a/eawx-build/Services/Process/ProcessRunner.cs
+++ b/eawx-build/Services/Process/ProcessRunner.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace EawXBuild.Services.Process {
+    public class ProcessRunner : IProcessRunner {
+
+        private System.Diagnostics.Process _process;
+        
+        public void Start(string executablePath) {
+            Start(executablePath, null);
+        }
+
+        public void Start(string executablePath, string arguments) {
+            _process = new System.Diagnostics.Process {
+                StartInfo = new ProcessStartInfo {
+                    FileName = executablePath,
+                    WorkingDirectory = System.Environment.CurrentDirectory,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    RedirectStandardInput = true,
+                    Arguments = arguments
+                }
+            };
+
+            _process.Start();
+            Console.WriteLine(_process.StandardOutput.ReadToEnd());
+        }
+
+        public void WaitForExit() {
+            _process.WaitForExit();
+        }
+    }
+}

--- a/eawx-build/Tasks/RunProcessTask.cs
+++ b/eawx-build/Tasks/RunProcessTask.cs
@@ -15,6 +15,7 @@ namespace EawXBuild.Tasks {
         }
 
         public void Run() {
+            if (_filesystem.Path.IsPathRooted(ExecutablePath)) throw new NoRelativePathException(ExecutablePath);
             _runner.Start(ExecutablePath, Arguments);
             _runner.WaitForExit();
             if(_runner.ExitCode != 0) throw new ProcessFailedException();

--- a/eawx-build/Tasks/RunProcessTask.cs
+++ b/eawx-build/Tasks/RunProcessTask.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.IO.Abstractions;
+using EawXBuild.Core;
+using EawXBuild.Services.Process;
+
+namespace EawXBuild.Tasks {
+    public class RunProcessTask : ITask {
+        private readonly IProcessRunner _runner;
+        private readonly IFileSystem _filesystem;
+
+        public RunProcessTask(IProcessRunner runner, IFileSystem filesystem) {
+            _runner = runner;
+            _filesystem = filesystem;
+        }
+
+        public void Run() {
+            if (!_filesystem.File.Exists(ExecutablePath))
+                throw new FileNotFoundException();
+
+            _runner.Start(ExecutablePath, Arguments);
+            _runner.WaitForExit();
+        }
+
+        public string ExecutablePath { get; set; }
+        public string Arguments { get; set; }
+    }
+}

--- a/eawx-build/Tasks/RunProcessTask.cs
+++ b/eawx-build/Tasks/RunProcessTask.cs
@@ -15,9 +15,6 @@ namespace EawXBuild.Tasks {
         }
 
         public void Run() {
-            if (!_filesystem.File.Exists(ExecutablePath))
-                throw new FileNotFoundException();
-
             _runner.Start(ExecutablePath, Arguments);
             _runner.WaitForExit();
             if(_runner.ExitCode != 0) throw new ProcessFailedException();

--- a/eawx-build/Tasks/RunProcessTask.cs
+++ b/eawx-build/Tasks/RunProcessTask.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.IO.Abstractions;
 using EawXBuild.Core;
+using EawXBuild.Exceptions;
 using EawXBuild.Services.Process;
 
 namespace EawXBuild.Tasks {
@@ -19,6 +20,7 @@ namespace EawXBuild.Tasks {
 
             _runner.Start(ExecutablePath, Arguments);
             _runner.WaitForExit();
+            if(_runner.ExitCode != 0) throw new ProcessFailedException();
         }
 
         public string ExecutablePath { get; set; }


### PR DESCRIPTION
Runs a process using a `IProcessRunner` which is a simple abstraction over the `Process` class for testability.

Something I added, but I'm not sure about yet: 
Currently I'm catching errors in the `Project` class, but maybe we want to move that even higher up in the call order, since we probably want to exit with code 1 when something goes wrong. If Project catches errors that information is lost unless we want to return a result from `RunJobAsync()`