### PR TITLE
Bump All Dependencies

### DIFF
--- a/eawx-build-test/eawx-build-test.csproj
+++ b/eawx-build-test/eawx-build-test.csproj
@@ -13,14 +13,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.2.21" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.8" />
     <PackageReference Include="semver" Version="2.0.6" />
   </ItemGroup>
 

--- a/eawx-build/eawx-build.csproj
+++ b/eawx-build/eawx-build.csproj
@@ -26,13 +26,13 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.9" />
-    <PackageReference Include="NLua" Version="1.5.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
+    <PackageReference Include="NLua" Version="1.5.6" />
     <PackageReference Include="semver" Version="2.0.6" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.2.21" />
+    <PackageReference Include="System.IO.Abstractions" Version="13.2.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Bumps [System.IO.Abstractions.TestingHelpers](https://github.com/System-IO-Abstractions/System.IO.Abstractions) from 12.2.21 to 13.2.8.
  - [Release notes](https://github.com/System-IO-Abstractions/System.IO.Abstractions/releases)
  - [Commits](https://github.com/System-IO-Abstractions/System.IO.Abstractions/compare/v12.2.21...v13.2.8)
- Bumps [System.IO.Abstractions](https://github.com/System-IO-Abstractions/System.IO.Abstractions) from 12.2.21 to 13.2.8.
  - [Release notes](https://github.com/System-IO-Abstractions/System.IO.Abstractions/releases)
  - [Commits](https://github.com/System-IO-Abstractions/System.IO.Abstractions/compare/v12.2.21...v13.2.8)
- Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 16.8.0 to 16.8.3.
  - [Release notes](https://github.com/microsoft/vstest/releases)
  - [Commits](https://github.com/microsoft/vstest/compare/v16.8.0...v16.8.3)
- Bumps [NLua](https://github.com/nlua/nlua) from 1.5.4 to 1.5.6.
  - [Release notes](https://github.com/nlua/nlua/releases)
  - [Commits](https://github.com/nlua/nlua/compare/v1.5.4...v1.5.6)
- Bumps [Microsoft.Extensions.Logging.Debug](https://github.com/dotnet/runtime) from 3.1.9 to 5.0.0.
  - [Release notes](https://github.com/dotnet/runtime/releases)
  - [Commits](https://github.com/dotnet/runtime/commits)