### PR TITLE
Maintenance Update

### DIFF
--- a/eawx-build-test/Configuration/ConfigurationUtilityTest.cs
+++ b/eawx-build-test/Configuration/ConfigurationUtilityTest.cs
@@ -1,9 +1,11 @@
 using EawXBuild.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration {
+namespace EawXBuildTest.Configuration
+{
     [TestClass]
-    public class ConfigurationUtilityTest {
+    public class ConfigurationUtilityTest
+    {
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
         [DataRow("0.0.0", ConfigVersion.Invalid, true)]
@@ -12,7 +14,8 @@ namespace EawXBuildTest.Configuration {
         [DataRow("1.20.30-rc1", ConfigVersion.V1, true)]
         [DataRow("Abracadabra", ConfigVersion.Invalid, true)]
         [DataRow("Abracadabra", ConfigVersion.V1, false)]
-        public void Test__IsVersionMatch__ReturnsExpected(string semVer, ConfigVersion version, bool expected) {
+        public void Test__IsVersionMatch__ReturnsExpected(string semVer, ConfigVersion version, bool expected)
+        {
             bool actual = ConfigurationUtility.IsVersionMatch(semVer, version);
             Assert.AreEqual(expected, actual);
         }
@@ -24,7 +27,8 @@ namespace EawXBuildTest.Configuration {
         [DataRow("1.0.0", ConfigVersion.V1)]
         [DataRow("1", ConfigVersion.Invalid)]
         [DataRow("Abracadabra", ConfigVersion.Invalid)]
-        public void Test__GetConfigVersionInternal__ReturnsExpected(string semVer, ConfigVersion expected) {
+        public void Test__GetConfigVersionInternal__ReturnsExpected(string semVer, ConfigVersion expected)
+        {
             ConfigVersion actual = ConfigurationUtility.GetConfigVersionInternal(semVer);
             Assert.AreEqual(expected, actual);
         }

--- a/eawx-build-test/Configuration/FrontendAgnostic/BuildComponentFactoryTest.cs
+++ b/eawx-build-test/Configuration/FrontendAgnostic/BuildComponentFactoryTest.cs
@@ -1,91 +1,101 @@
 using System;
 using EawXBuild.Configuration.FrontendAgnostic;
 using EawXBuild.Core;
-using EawXBuild.Steam;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.FrontendAgnostic {
+namespace EawXBuildTest.Configuration.FrontendAgnostic
+{
     [TestClass]
-    public class BuildComponentFactoryTest {
+    public class BuildComponentFactoryTest
+    {
         [TestMethod]
-        public void BuildComponentFactory__WhenCallingMakeProject__ShouldReturnProject() {
-            var sut = new BuildComponentFactory();
+        public void BuildComponentFactory__WhenCallingMakeProject__ShouldReturnProject()
+        {
+            BuildComponentFactory sut = new BuildComponentFactory();
 
-            var project = sut.MakeProject();
+            IProject project = sut.MakeProject();
 
             Assert.IsInstanceOfType(project, typeof(Project));
         }
 
         [TestMethod]
-        public void BuildComponentFactory__WhenCallingMakeJob__ShouldReturnJob() {
-            var sut = new BuildComponentFactory();
+        public void BuildComponentFactory__WhenCallingMakeJob__ShouldReturnJob()
+        {
+            BuildComponentFactory sut = new BuildComponentFactory();
 
-            var job = sut.MakeJob("job");
+            IJob job = sut.MakeJob("job");
 
             Assert.IsInstanceOfType(job, typeof(Job));
             Assert.AreEqual("job", job.Name);
         }
 
         [TestMethod]
-        public void BuildComponentFactory__WhenCallingTaskWith_Copy__ShouldReturnCopyTaskBuilder() {
-            var sut = new BuildComponentFactory();
+        public void BuildComponentFactory__WhenCallingTaskWith_Copy__ShouldReturnCopyTaskBuilder()
+        {
+            BuildComponentFactory sut = new BuildComponentFactory();
 
-            var taskBuilder = sut.Task("Copy");
+            ITaskBuilder taskBuilder = sut.Task("Copy");
 
             Assert.IsInstanceOfType(taskBuilder, typeof(CopyTaskBuilder));
         }
 
         [TestMethod]
-        public void BuildComponentFactory__WhenCallingTaskWith_RunProgram__ShouldReturnRunProcessTaskBuilder() {
-            var sut = new BuildComponentFactory();
+        public void BuildComponentFactory__WhenCallingTaskWith_RunProgram__ShouldReturnRunProcessTaskBuilder()
+        {
+            BuildComponentFactory sut = new BuildComponentFactory();
 
-            var taskBuilder = sut.Task("RunProgram");
+            ITaskBuilder taskBuilder = sut.Task("RunProgram");
 
             Assert.IsInstanceOfType(taskBuilder, typeof(RunProcessTaskBuilder));
         }
 
         [TestMethod]
-        public void BuildComponentFactory__WhenCallingTaskWith_Clean__ShouldReturnCleanTaskBuilder() {
-            var sut = new BuildComponentFactory();
+        public void BuildComponentFactory__WhenCallingTaskWith_Clean__ShouldReturnCleanTaskBuilder()
+        {
+            BuildComponentFactory sut = new BuildComponentFactory();
 
-            var taskBuilder = sut.Task("Clean");
+            ITaskBuilder taskBuilder = sut.Task("Clean");
 
             Assert.IsInstanceOfType(taskBuilder, typeof(CleanTaskBuilder));
         }
 
         [TestMethod]
-        public void BuildComponentFactory__WhenCallingTaskWith_SoftCopy__ShouldReturnCopyTaskBuilder() {
-            var sut = new BuildComponentFactory();
+        public void BuildComponentFactory__WhenCallingTaskWith_SoftCopy__ShouldReturnCopyTaskBuilder()
+        {
+            BuildComponentFactory sut = new BuildComponentFactory();
 
-            var taskBuilder = sut.Task("SoftCopy");
+            ITaskBuilder taskBuilder = sut.Task("SoftCopy");
 
             Assert.IsInstanceOfType(taskBuilder, typeof(CopyTaskBuilder));
         }
 
         [TestMethod]
         public void
-            BuildComponentFactory__WhenCallingTaskWith_CreateSteamWorkshopItem__ShouldReturnCreateSteamWorkshopItemTaskBuilder() {
-            var sut = new BuildComponentFactory();
+            BuildComponentFactory__WhenCallingTaskWith_CreateSteamWorkshopItem__ShouldReturnCreateSteamWorkshopItemTaskBuilder()
+        {
+            BuildComponentFactory sut = new BuildComponentFactory();
 
-            var taskBuilder = sut.Task("CreateSteamWorkshopItem");
+            ITaskBuilder taskBuilder = sut.Task("CreateSteamWorkshopItem");
 
             Assert.IsInstanceOfType(taskBuilder, typeof(CreateSteamWorkshopItemTaskBuilder));
         }
 
         [TestMethod]
         public void
-            BuildComponentFactory__WhenCallingTaskWith_UpdateSteamWorkshopItem__ShouldReturnUpdateSteamWorkshopItemTaskBuilder() {
-            var sut = new BuildComponentFactory();
+            BuildComponentFactory__WhenCallingTaskWith_UpdateSteamWorkshopItem__ShouldReturnUpdateSteamWorkshopItemTaskBuilder()
+        {
+            BuildComponentFactory sut = new BuildComponentFactory();
 
-            var taskBuilder = sut.Task("UpdateSteamWorkshopItem");
+            ITaskBuilder taskBuilder = sut.Task("UpdateSteamWorkshopItem");
 
             Assert.IsInstanceOfType(taskBuilder, typeof(UpdateSteamWorkshopItemTaskBuilder));
         }
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
-        public void BuildComponentFactory__WhenCallingTaskWithUnknownTaskType__ShouldThrowInvalidOperationException() {
-            var sut = new BuildComponentFactory();
+        public void BuildComponentFactory__WhenCallingTaskWithUnknownTaskType__ShouldThrowInvalidOperationException()
+        {
+            BuildComponentFactory sut = new BuildComponentFactory();
 
             sut.Task("Unknown");
         }

--- a/eawx-build-test/Configuration/FrontendAgnostic/CleanTaskBuilderTest.cs
+++ b/eawx-build-test/Configuration/FrontendAgnostic/CleanTaskBuilderTest.cs
@@ -4,18 +4,21 @@ using EawXBuild.Configuration.FrontendAgnostic;
 using EawXBuild.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.FrontendAgnostic {
+namespace EawXBuildTest.Configuration.FrontendAgnostic
+{
     [TestClass]
-    public class CleanTaskBuilderTest {
+    public class CleanTaskBuilderTest
+    {
         [TestMethod]
-        public void WhenBuildingCleanTaskWithNameAndDirectoryPath__ShouldReturnConfiguredCleanTask() {
+        public void WhenBuildingCleanTaskWithNameAndDirectoryPath__ShouldReturnConfiguredCleanTask()
+        {
             const string pathToDirectory = "Path/To/Directory";
             const string expectedId = "taskId";
             const string expectedName = "taskName";
 
-            var sut = new CleanTaskBuilder(new MockFileSystem());
+            CleanTaskBuilder sut = new CleanTaskBuilder(new MockFileSystem());
 
-            var task = (CleanTask) sut
+            CleanTask task = (CleanTask) sut
                 .With("Id", expectedId)
                 .With("Name", expectedName)
                 .With("Path", pathToDirectory)
@@ -28,8 +31,9 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
-        public void WhenBuildingCleanTaskWithUnknownConfigOption__ShouldThrowInvalidOperationException() {
-            var sut = new CleanTaskBuilder(new MockFileSystem());
+        public void WhenBuildingCleanTaskWithUnknownConfigOption__ShouldThrowInvalidOperationException()
+        {
+            CleanTaskBuilder sut = new CleanTaskBuilder(new MockFileSystem());
 
             sut.With("Unknown", "").Build();
         }

--- a/eawx-build-test/Configuration/FrontendAgnostic/CopyTaskBuilderTest.cs
+++ b/eawx-build-test/Configuration/FrontendAgnostic/CopyTaskBuilderTest.cs
@@ -6,9 +6,11 @@ using EawXBuild.Tasks;
 using EawXBuildTest.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.FrontendAgnostic {
+namespace EawXBuildTest.Configuration.FrontendAgnostic
+{
     [TestClass]
-    public class CopyTaskBuilderTest {
+    public class CopyTaskBuilderTest
+    {
         private const string TheSourcePath = "the/source/path";
         private const string TheDestPath = "the/dest/path";
         private const bool Recursive = true;
@@ -20,12 +22,13 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
 
         [TestMethod]
         public void
-            GivenSourcePathDestPathRecursiveAndFilePattern__WhenCallingBuild__ShouldReturnCopyTaskWithMatchingConfig() {
-            var sut = new CopyTaskBuilder(new CopyPolicyDummy(), new MockFileSystem());
+            GivenSourcePathDestPathRecursiveAndFilePattern__WhenCallingBuild__ShouldReturnCopyTaskWithMatchingConfig()
+        {
+            CopyTaskBuilder sut = new CopyTaskBuilder(new CopyPolicyDummy(), new MockFileSystem());
 
             ConfigureTask(sut);
 
-            var task = (CopyTask) sut.Build();
+            CopyTask task = (CopyTask) sut.Build();
 
             Assert.AreEqual(TaskId, task.Id);
             Assert.AreEqual(TaskName, task.Name);
@@ -37,23 +40,26 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
         }
 
         [TestMethod]
-        public void GivenTaskBuiltWithValidConfiguration__WhenRunningTask__ShouldCopyPolicyShouldBeCalled() {
-            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> {
+        public void GivenTaskBuiltWithValidConfiguration__WhenRunningTask__ShouldCopyPolicyShouldBeCalled()
+        {
+            MockFileSystem fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
                 {TheSourcePath, string.Empty}
             });
-            var copyPolicySpy = new CopyPolicySpy();
+            CopyPolicySpy copyPolicySpy = new CopyPolicySpy();
 
-            var sut = new CopyTaskBuilder(copyPolicySpy, fileSystem);
+            CopyTaskBuilder sut = new CopyTaskBuilder(copyPolicySpy, fileSystem);
 
             ConfigureTask(sut);
-            var task = (CopyTask) sut.Build();
+            CopyTask task = (CopyTask) sut.Build();
 
             task.Run();
 
             Assert.IsTrue(copyPolicySpy.CopyCalled);
         }
 
-        private static void ConfigureTask(CopyTaskBuilder sut) {
+        private static void ConfigureTask(CopyTaskBuilder sut)
+        {
             sut.With("Id", TaskId)
                 .With("Name", TaskName)
                 .With("CopyFromPath", TheSourcePath)
@@ -65,8 +71,9 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
-        public void WhenCallingWith_WithInvalidConfigOption__ShouldThrowInvalidOperationException() {
-            var sut = new CopyTaskBuilder(new CopyPolicyDummy(), new MockFileSystem());
+        public void WhenCallingWith_WithInvalidConfigOption__ShouldThrowInvalidOperationException()
+        {
+            CopyTaskBuilder sut = new CopyTaskBuilder(new CopyPolicyDummy(), new MockFileSystem());
 
             sut.With("InvalidOption", string.Empty);
         }

--- a/eawx-build-test/Configuration/FrontendAgnostic/CreateSteamWorkshopItemTaskBuilderTest.cs
+++ b/eawx-build-test/Configuration/FrontendAgnostic/CreateSteamWorkshopItemTaskBuilderTest.cs
@@ -2,13 +2,14 @@ using System;
 using System.Collections.Generic;
 using EawXBuild.Configuration.FrontendAgnostic;
 using EawXBuild.Steam;
-using EawXBuild.Tasks;
 using EawXBuild.Tasks.Steam;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.FrontendAgnostic {
+namespace EawXBuildTest.Configuration.FrontendAgnostic
+{
     [TestClass]
-    public class CreateSteamWorkshopItemTaskBuilderTest {
+    public class CreateSteamWorkshopItemTaskBuilderTest
+    {
         private const uint AppId = 32470;
         private const string Title = "My title";
         private const string DescriptionFilePath = "path/to/description";
@@ -17,10 +18,11 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
         private readonly HashSet<string> Tags = new HashSet<string> {"EAW", "FOC"};
 
         [TestMethod]
-        public void GivenCreateSteamWorkshopItemTaskBuilder__WhenConfiguring__ShouldReturnConfiguredTask() {
-            var sut = new CreateSteamWorkshopItemTaskBuilder();
+        public void GivenCreateSteamWorkshopItemTaskBuilder__WhenConfiguring__ShouldReturnConfiguredTask()
+        {
+            CreateSteamWorkshopItemTaskBuilder sut = new CreateSteamWorkshopItemTaskBuilder();
 
-            var actual = (CreateSteamWorkshopItemTask) sut
+            CreateSteamWorkshopItemTask actual = (CreateSteamWorkshopItemTask) sut
                 .With("AppId", AppId)
                 .With("Title", Title)
                 .With("DescriptionFilePath", DescriptionFilePath)
@@ -41,31 +43,35 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
 
         [TestMethod]
         public void
-            GivenCreateSteamWorkshopItemTaskBuilder__WhenConfiguringWithPrivateVisibility__ShouldReturnConfiguredTaskWithPrivateVisibility() {
-            var sut = new CreateSteamWorkshopItemTaskBuilder();
+            GivenCreateSteamWorkshopItemTaskBuilder__WhenConfiguringWithPrivateVisibility__ShouldReturnConfiguredTaskWithPrivateVisibility()
+        {
+            CreateSteamWorkshopItemTaskBuilder sut = new CreateSteamWorkshopItemTaskBuilder();
 
-            var actual = (CreateSteamWorkshopItemTask) sut.With("Visibility", WorkshopItemVisibility.Private).Build();
-
-            Assert.AreEqual(WorkshopItemVisibility.Private, actual.ChangeSet.Visibility);
-        }
-
-        [TestMethod]
-        public void
-            GivenCreateSteamWorkshopItemTaskBuilder__WhenConfiguringWithNullVisibility__ShouldReturnTaskWithPrivateVisibility() {
-            var sut = new CreateSteamWorkshopItemTaskBuilder();
-
-            var actual = (CreateSteamWorkshopItemTask) sut.With("Visibility", null).Build();
+            CreateSteamWorkshopItemTask actual =
+                (CreateSteamWorkshopItemTask) sut.With("Visibility", WorkshopItemVisibility.Private).Build();
 
             Assert.AreEqual(WorkshopItemVisibility.Private, actual.ChangeSet.Visibility);
         }
 
         [TestMethod]
         public void
-            GivenCreateSteamWorkshopItemTaskBuilder_WhenConfiguringTaskWithAppIdOfTypeInt_ShouldReturnTaskWithAppIdOfUInt() {
-            var sut = new CreateSteamWorkshopItemTaskBuilder();
+            GivenCreateSteamWorkshopItemTaskBuilder__WhenConfiguringWithNullVisibility__ShouldReturnTaskWithPrivateVisibility()
+        {
+            CreateSteamWorkshopItemTaskBuilder sut = new CreateSteamWorkshopItemTaskBuilder();
+
+            CreateSteamWorkshopItemTask actual = (CreateSteamWorkshopItemTask) sut.With("Visibility", null).Build();
+
+            Assert.AreEqual(WorkshopItemVisibility.Private, actual.ChangeSet.Visibility);
+        }
+
+        [TestMethod]
+        public void
+            GivenCreateSteamWorkshopItemTaskBuilder_WhenConfiguringTaskWithAppIdOfTypeInt_ShouldReturnTaskWithAppIdOfUInt()
+        {
+            CreateSteamWorkshopItemTaskBuilder sut = new CreateSteamWorkshopItemTaskBuilder();
 
             const int appId = 32470;
-            var actual = (CreateSteamWorkshopItemTask) sut.With("AppId", appId).Build();
+            CreateSteamWorkshopItemTask actual = (CreateSteamWorkshopItemTask) sut.With("AppId", appId).Build();
 
             const uint expected = appId;
             Assert.AreEqual(expected, actual.AppId);
@@ -73,8 +79,9 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
-        public void WhenCallingWithInvalidConfigOption__ShouldThrowInvalidOperationException() {
-            var sut = new CreateSteamWorkshopItemTaskBuilder();
+        public void WhenCallingWithInvalidConfigOption__ShouldThrowInvalidOperationException()
+        {
+            CreateSteamWorkshopItemTaskBuilder sut = new CreateSteamWorkshopItemTaskBuilder();
 
             sut.With("InvalidOption", string.Empty);
         }

--- a/eawx-build-test/Configuration/FrontendAgnostic/RunProcessTaskBuilderTest.cs
+++ b/eawx-build-test/Configuration/FrontendAgnostic/RunProcessTaskBuilderTest.cs
@@ -4,9 +4,11 @@ using EawXBuild.Configuration.FrontendAgnostic;
 using EawXBuild.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.FrontendAgnostic {
+namespace EawXBuildTest.Configuration.FrontendAgnostic
+{
     [TestClass]
-    public class RunProcessTaskBuilderTest {
+    public class RunProcessTaskBuilderTest
+    {
         private const string PathToExe = "Path/To/Exe";
         private const string Args = "--first=5 --second=yes";
         private const string WorkingDirectory = "Path/To/Another/Dir";
@@ -16,10 +18,11 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
         private const string TaskName = "TaskName";
 
         [TestMethod]
-        public void WhenBuildingRunProcessTaskWithExePathAndArguments__ShouldReturnConfiguredTask() {
-            var sut = new RunProcessTaskBuilder(new MockFileSystem());
+        public void WhenBuildingRunProcessTaskWithExePathAndArguments__ShouldReturnConfiguredTask()
+        {
+            RunProcessTaskBuilder sut = new RunProcessTaskBuilder(new MockFileSystem());
 
-            var task = (RunProcessTask) sut
+            RunProcessTask task = (RunProcessTask) sut
                 .With("Id", TaskId)
                 .With("Name", TaskName)
                 .With("ExecutablePath", PathToExe)
@@ -38,8 +41,9 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
-        public void WhenBuildingWithUnknownConfigOption__ShouldThrowInvalidOperationException() {
-            var sut = new RunProcessTaskBuilder(new MockFileSystem());
+        public void WhenBuildingWithUnknownConfigOption__ShouldThrowInvalidOperationException()
+        {
+            RunProcessTaskBuilder sut = new RunProcessTaskBuilder(new MockFileSystem());
 
             sut.With("UnknownOption", string.Empty);
         }

--- a/eawx-build-test/Configuration/FrontendAgnostic/UpdateSteamWorkshopItemTaskBuilderTest.cs
+++ b/eawx-build-test/Configuration/FrontendAgnostic/UpdateSteamWorkshopItemTaskBuilderTest.cs
@@ -2,13 +2,14 @@ using System;
 using System.Collections.Generic;
 using EawXBuild.Configuration.FrontendAgnostic;
 using EawXBuild.Steam;
-using EawXBuild.Tasks;
 using EawXBuild.Tasks.Steam;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.FrontendAgnostic {
+namespace EawXBuildTest.Configuration.FrontendAgnostic
+{
     [TestClass]
-    public class UpdateSteamWorkshopItemTaskBuilderTest {
+    public class UpdateSteamWorkshopItemTaskBuilderTest
+    {
         private const uint AppId = 32470;
         private const ulong ItemId = 1234;
         private const string Title = "My title";
@@ -18,10 +19,11 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
         private readonly HashSet<string> Tags = new HashSet<string> {"EAW", "FOC"};
 
         [TestMethod]
-        public void GivenTaskBuilder_WhenConfiguringTask_ShouldReturnConfiguredTask() {
-            var sut = new UpdateSteamWorkshopItemTaskBuilder();
+        public void GivenTaskBuilder_WhenConfiguringTask_ShouldReturnConfiguredTask()
+        {
+            UpdateSteamWorkshopItemTaskBuilder sut = new UpdateSteamWorkshopItemTaskBuilder();
 
-            var actual = (UpdateSteamWorkshopItemTask) sut.With("AppId", AppId)
+            UpdateSteamWorkshopItemTask actual = (UpdateSteamWorkshopItemTask) sut.With("AppId", AppId)
                 .With("ItemId", ItemId)
                 .With("Title", Title)
                 .With("DescriptionFilePath", DescriptionFilePath)
@@ -43,40 +45,45 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
 
         [TestMethod]
         public void
-            GivenTaskBuilder__WhenConfiguringWithPrivateVisibility__ShouldReturnConfiguredTaskWithPrivateVisibility() {
-            var sut = new UpdateSteamWorkshopItemTaskBuilder();
+            GivenTaskBuilder__WhenConfiguringWithPrivateVisibility__ShouldReturnConfiguredTaskWithPrivateVisibility()
+        {
+            UpdateSteamWorkshopItemTaskBuilder sut = new UpdateSteamWorkshopItemTaskBuilder();
 
-            var actual = (UpdateSteamWorkshopItemTask) sut.With("Visibility", WorkshopItemVisibility.Private).Build();
-
-            Assert.AreEqual(WorkshopItemVisibility.Private, actual.ChangeSet.Visibility);
-        }
-
-        [TestMethod]
-        public void GivenTaskBuilder__WhenConfiguringWithNullVisibility__ShouldReturnTaskWithPrivateVisibility() {
-            var sut = new UpdateSteamWorkshopItemTaskBuilder();
-
-            var actual = (UpdateSteamWorkshopItemTask) sut.With("Visibility", null).Build();
+            UpdateSteamWorkshopItemTask actual =
+                (UpdateSteamWorkshopItemTask) sut.With("Visibility", WorkshopItemVisibility.Private).Build();
 
             Assert.AreEqual(WorkshopItemVisibility.Private, actual.ChangeSet.Visibility);
         }
 
         [TestMethod]
-        public void GivenTaskBuilder_WhenConfiguringTaskWithAppIdOfTypeInt_ShouldReturnTaskWithAppIdOfUInt() {
-            var sut = new UpdateSteamWorkshopItemTaskBuilder();
+        public void GivenTaskBuilder__WhenConfiguringWithNullVisibility__ShouldReturnTaskWithPrivateVisibility()
+        {
+            UpdateSteamWorkshopItemTaskBuilder sut = new UpdateSteamWorkshopItemTaskBuilder();
+
+            UpdateSteamWorkshopItemTask actual = (UpdateSteamWorkshopItemTask) sut.With("Visibility", null).Build();
+
+            Assert.AreEqual(WorkshopItemVisibility.Private, actual.ChangeSet.Visibility);
+        }
+
+        [TestMethod]
+        public void GivenTaskBuilder_WhenConfiguringTaskWithAppIdOfTypeInt_ShouldReturnTaskWithAppIdOfUInt()
+        {
+            UpdateSteamWorkshopItemTaskBuilder sut = new UpdateSteamWorkshopItemTaskBuilder();
 
             const int appId = 32470;
-            var actual = (UpdateSteamWorkshopItemTask) sut.With("AppId", appId).Build();
+            UpdateSteamWorkshopItemTask actual = (UpdateSteamWorkshopItemTask) sut.With("AppId", appId).Build();
 
             const uint expected = appId;
             Assert.AreEqual(expected, actual.AppId);
         }
 
         [TestMethod]
-        public void GivenTaskBuilder_WhenConfiguringTaskWithItemIdOfTypeInt_ShouldReturnTaskWithItemIdOfULong() {
-            var sut = new UpdateSteamWorkshopItemTaskBuilder();
+        public void GivenTaskBuilder_WhenConfiguringTaskWithItemIdOfTypeInt_ShouldReturnTaskWithItemIdOfULong()
+        {
+            UpdateSteamWorkshopItemTaskBuilder sut = new UpdateSteamWorkshopItemTaskBuilder();
 
             const int itemId = 123456;
-            var actual = (UpdateSteamWorkshopItemTask) sut.With("ItemId", itemId).Build();
+            UpdateSteamWorkshopItemTask actual = (UpdateSteamWorkshopItemTask) sut.With("ItemId", itemId).Build();
 
             const ulong expected = itemId;
             Assert.AreEqual(expected, actual.ItemId);
@@ -84,8 +91,9 @@ namespace EawXBuildTest.Configuration.FrontendAgnostic {
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
-        public void WhenCallingWithInvalidConfigOption__ShouldThrowInvalidOperationException() {
-            var sut = new UpdateSteamWorkshopItemTaskBuilder();
+        public void WhenCallingWithInvalidConfigOption__ShouldThrowInvalidOperationException()
+        {
+            UpdateSteamWorkshopItemTaskBuilder sut = new UpdateSteamWorkshopItemTaskBuilder();
 
             sut.With("InvalidOption", string.Empty);
         }

--- a/eawx-build-test/Configuration/Lua/v1/EawCiLuaEnvironmentTest.cs
+++ b/eawx-build-test/Configuration/Lua/v1/EawCiLuaEnvironmentTest.cs
@@ -6,144 +6,161 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NLua;
 using static EawXBuildTest.Configuration.Lua.v1.NLuaUtilities;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
     [TestClass]
-    public class EawCiLuaEnvironmentTest {
+    public class EawCiLuaEnvironmentTest
+    {
         private LuaMockFileSystemParser _luaParser;
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             _luaParser = new LuaMockFileSystemParser(new MockFileSystem());
         }
 
         [TestCleanup]
-        public void TearDown() {
+        public void TearDown()
+        {
             _luaParser.Dispose();
         }
 
         [TestMethod]
-        public void WhenCallingCopy__ShouldCallBuildComponentFactoryWithCopyTaskName() {
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
+        public void WhenCallingCopy__ShouldCallBuildComponentFactoryWithCopyTaskName()
+        {
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
             sut.Copy(string.Empty, string.Empty);
 
             Assert.AreSame("Copy", factorySpy.ActualTaskTypeName);
         }
 
         [TestMethod]
-        public void WhenCallingCopy__ShouldReturnLuaCopyTask() {
-            var factoryStub = new BuildComponentFactoryStub();
-            var sut = new EawCiLuaEnvironment(factoryStub, _luaParser);
-            var actual = sut.Copy(string.Empty, string.Empty);
+        public void WhenCallingCopy__ShouldReturnLuaCopyTask()
+        {
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factoryStub, _luaParser);
+            ILuaTask actual = sut.Copy(string.Empty, string.Empty);
 
             Assert.IsInstanceOfType(actual, typeof(LuaCopyTask));
         }
 
         [TestMethod]
-        public void WhenCallingLink__ShouldCallBuildComponentFactoryWithSoftCopyTaskName() {
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
+        public void WhenCallingLink__ShouldCallBuildComponentFactoryWithSoftCopyTaskName()
+        {
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
             sut.Link(string.Empty, string.Empty);
 
             Assert.AreSame("SoftCopy", factorySpy.ActualTaskTypeName);
         }
 
         [TestMethod]
-        public void WhenCallingLink__ShouldReturnLuaCopyTask() {
-            var factoryStub = new BuildComponentFactoryStub();
-            var sut = new EawCiLuaEnvironment(factoryStub, _luaParser);
-            var actual = sut.Link(string.Empty, string.Empty);
+        public void WhenCallingLink__ShouldReturnLuaCopyTask()
+        {
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factoryStub, _luaParser);
+            ILuaTask actual = sut.Link(string.Empty, string.Empty);
 
             Assert.IsInstanceOfType(actual, typeof(LuaCopyTask));
         }
 
         [TestMethod]
-        public void WhenCallingClean__ShouldCallBuildComponentFactoryWithCleanTaskName() {
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
+        public void WhenCallingClean__ShouldCallBuildComponentFactoryWithCleanTaskName()
+        {
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
             sut.Clean(string.Empty);
 
             Assert.AreSame("Clean", factorySpy.ActualTaskTypeName);
         }
 
         [TestMethod]
-        public void WhenCallingClean__ShouldReturnLuaCleanTask() {
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
-            var actual = sut.Clean(string.Empty);
+        public void WhenCallingClean__ShouldReturnLuaCleanTask()
+        {
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
+            ILuaTask actual = sut.Clean(string.Empty);
 
             Assert.IsInstanceOfType(actual, typeof(LuaCleanTask));
         }
 
         [TestMethod]
-        public void WhenCallingRunProcess__ShouldCallBuildComponentFactoryWithRunProgramTaskName() {
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
+        public void WhenCallingRunProcess__ShouldCallBuildComponentFactoryWithRunProgramTaskName()
+        {
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
             sut.RunProcess(string.Empty);
 
             Assert.AreSame("RunProgram", factorySpy.ActualTaskTypeName);
         }
 
         [TestMethod]
-        public void WhenCallingRunProcess__ShouldReturnLuaRunProcessTask() {
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
-            var actual = sut.RunProcess(string.Empty);
+        public void WhenCallingRunProcess__ShouldReturnLuaRunProcessTask()
+        {
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
+            ILuaTask actual = sut.RunProcess(string.Empty);
 
             Assert.IsInstanceOfType(actual, typeof(LuaRunProcessTask));
         }
 
         [TestMethod]
         public void
-            WhenCallingCreateSteamWorkshopItem__ShouldCallBuildComponentFactoryWithCreateWorkshopItemTaskName() {
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
+            WhenCallingCreateSteamWorkshopItem__ShouldCallBuildComponentFactoryWithCreateWorkshopItemTaskName()
+        {
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
 
-            var table = MakeLuaTable(_luaParser.Lua, "the_table");
+            LuaTable table = MakeLuaTable(_luaParser.Lua, "the_table");
             sut.CreateSteamWorkshopItem(table);
 
             Assert.AreSame("CreateSteamWorkshopItem", factorySpy.ActualTaskTypeName);
         }
 
         [TestMethod]
-        public void WhenCallingCreateSteamWorkshopItem__ShouldReturnLuaCreateSteamWorkshopItemTask() {
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
+        public void WhenCallingCreateSteamWorkshopItem__ShouldReturnLuaCreateSteamWorkshopItemTask()
+        {
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
 
-            var table = MakeLuaTable(_luaParser.Lua, "the_table");
-            var actual = sut.CreateSteamWorkshopItem(table);
+            LuaTable table = MakeLuaTable(_luaParser.Lua, "the_table");
+            ILuaTask actual = sut.CreateSteamWorkshopItem(table);
 
             Assert.IsInstanceOfType(actual, typeof(LuaCreateSteamWorkshopItemTask));
         }
 
         [TestMethod]
         public void
-            WhenCallingUpdateSteamWorkshopItem__ShouldCallBuildComponentFactoryWithUpdateWorkshopItemTaskName() {
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
+            WhenCallingUpdateSteamWorkshopItem__ShouldCallBuildComponentFactoryWithUpdateWorkshopItemTaskName()
+        {
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
 
-            var table = MakeLuaTable(_luaParser.Lua, "the_table");
+            LuaTable table = MakeLuaTable(_luaParser.Lua, "the_table");
             sut.UpdateSteamWorkshopItem(table);
 
             Assert.AreSame("UpdateSteamWorkshopItem", factorySpy.ActualTaskTypeName);
         }
 
         [TestMethod]
-        public void WhenCallingUpdateSteamWorkshopItem__ShouldReturnLuaUpdateSteamWorkshopItemTask() {
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
+        public void WhenCallingUpdateSteamWorkshopItem__ShouldReturnLuaUpdateSteamWorkshopItemTask()
+        {
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(factorySpy, _luaParser);
 
-            var table = MakeLuaTable(_luaParser.Lua, "the_table");
-            var actual = sut.UpdateSteamWorkshopItem(table);
+            LuaTable table = MakeLuaTable(_luaParser.Lua, "the_table");
+            ILuaTask actual = sut.UpdateSteamWorkshopItem(table);
 
             Assert.IsInstanceOfType(actual, typeof(LuaUpdateSteamWorkshopItemTask));
         }
 
         [TestMethod]
-        public void GivenNewEawCiLuaEnvironment__OnCreation__ShouldPushVisibilityTableToLuaEnvironment() {
-            var sut = new EawCiLuaEnvironment(new BuildComponentFactoryStub(), _luaParser);
+        public void GivenNewEawCiLuaEnvironment__OnCreation__ShouldPushVisibilityTableToLuaEnvironment()
+        {
+            EawCiLuaEnvironment sut = new EawCiLuaEnvironment(new BuildComponentFactoryStub(), _luaParser);
 
-            var visibilityTable = _luaParser.Lua.GetTable("visibility");
+            LuaTable visibilityTable = _luaParser.Lua.GetTable("visibility");
             Assert.AreEqual(visibilityTable["private"], WorkshopItemVisibility.Private);
             Assert.AreEqual(visibilityTable["public"], WorkshopItemVisibility.Public);
         }

--- a/eawx-build-test/Configuration/Lua/v1/LuaBuildConfigParserTest.cs
+++ b/eawx-build-test/Configuration/Lua/v1/LuaBuildConfigParserTest.cs
@@ -7,19 +7,22 @@ using EawXBuild.Steam;
 using EawXBuildTest.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
     [TestClass]
-    public class LuaBuildConfigParserTest {
+    public class LuaBuildConfigParserTest
+    {
         private const string Path = "luaConfig.lua";
-
-        private MockFileSystem _fileSystem;
-        private MockFileData _mockFileData;
-        private LuaMockFileSystemParser _luaMockFileParser;
 
         private static readonly string[] ExpectedTags = {"EAW", "FOC"};
 
+        private MockFileSystem _fileSystem;
+        private LuaMockFileSystemParser _luaMockFileParser;
+        private MockFileData _mockFileData;
+
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             _mockFileData = new MockFileData(string.Empty);
             _fileSystem = new MockFileSystem();
             _fileSystem.AddFile(Path, _mockFileData);
@@ -27,49 +30,53 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
         }
 
         [TestMethod]
-        public void GivenConfigWithProject__WhenParsing__ShouldReturnProject() {
+        public void GivenConfigWithProject__WhenParsing__ShouldReturnProject()
+        {
             const string lua = "project('test')";
             _mockFileData.TextContents = lua;
 
-            var factoryStub = new BuildComponentFactoryStub();
-            var projects = MakeSutAndParse(factoryStub);
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub();
+            IEnumerable<IProject> projects = MakeSutAndParse(factoryStub);
 
-            var actual = projects.First();
+            IProject actual = projects.First();
             Assert.AreEqual("test", actual.Name);
         }
 
         [TestMethod]
-        public void GivenConfigWithProjectAndDifferentName__WhenParsing__ShouldReturnProject() {
+        public void GivenConfigWithProjectAndDifferentName__WhenParsing__ShouldReturnProject()
+        {
             const string lua = "project('another-project')";
             _mockFileData.TextContents = lua;
 
-            var factoryStub = new BuildComponentFactoryStub();
-            var projects = MakeSutAndParse(factoryStub);
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub();
+            IEnumerable<IProject> projects = MakeSutAndParse(factoryStub);
 
-            var actual = projects.First();
+            IProject actual = projects.First();
             Assert.AreEqual("another-project", actual.Name);
         }
 
         [TestMethod]
-        public void GivenConfigWithProjectAndJob__WhenParsing__ProjectShouldHaveJob() {
+        public void GivenConfigWithProjectAndJob__WhenParsing__ProjectShouldHaveJob()
+        {
             const string lua = @"
                 local p = project('test')
                 p:add_job('test-job')  
             ";
             _mockFileData.TextContents = lua;
 
-            var jobStub = new JobStub();
-            var factoryStub = MakeBuildComponentFactoryStub(jobStub);
-            var projects = MakeSutAndParse(factoryStub);
+            JobStub jobStub = new JobStub();
+            BuildComponentFactoryStub factoryStub = MakeBuildComponentFactoryStub(jobStub);
+            IEnumerable<IProject> projects = MakeSutAndParse(factoryStub);
 
-            var actual = projects.First() as ProjectStub;
-            var actualJob = actual?.Jobs.First();
+            ProjectStub actual = projects.First() as ProjectStub;
+            IJob actualJob = actual?.Jobs.First();
             Assert.AreSame(jobStub, actualJob);
             Assert.AreEqual("test-job", actualJob?.Name);
         }
 
         [TestMethod]
-        public void GivenConfigWithProjectWithJobAndCopyTask__WhenParsing__JobShouldHaveTask() {
+        public void GivenConfigWithProjectWithJobAndCopyTask__WhenParsing__JobShouldHaveTask()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -77,18 +84,19 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var jobStub = new JobStub();
-            var taskDummy = new TaskDummy();
-            var factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
+            JobStub jobStub = new JobStub();
+            TaskDummy taskDummy = new TaskDummy();
+            BuildComponentFactoryStub factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
 
             MakeSutAndParse(factoryStub);
 
-            var actualTask = jobStub.Tasks.First();
+            ITask actualTask = jobStub.Tasks.First();
             Assert.AreEqual(taskDummy, actualTask);
         }
 
         [TestMethod]
-        public void GivenConfigWithCopyTaskWithSettings__WhenParsing__JobShouldHaveTask() {
+        public void GivenConfigWithCopyTaskWithSettings__WhenParsing__JobShouldHaveTask()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -99,18 +107,19 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var jobStub = new JobStub();
-            var taskDummy = new TaskDummy();
-            var factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
+            JobStub jobStub = new JobStub();
+            TaskDummy taskDummy = new TaskDummy();
+            BuildComponentFactoryStub factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
 
             MakeSutAndParse(factoryStub);
 
-            var actualTask = jobStub.Tasks.First();
+            ITask actualTask = jobStub.Tasks.First();
             Assert.AreEqual(taskDummy, actualTask);
         }
 
         [TestMethod]
-        public void GivenConfigWithCopyTaskWithSettings__WhenParsing__TaskShouldBeConfiguredCorrectly() {
+        public void GivenConfigWithCopyTaskWithSettings__WhenParsing__TaskShouldBeConfiguredCorrectly()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -121,7 +130,8 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object> {
+            TaskBuilderMock taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object>
+            {
                 {"CopyFromPath", "a"},
                 {"CopyToPath", "b"},
                 {"AlwaysOverwrite", true},
@@ -129,14 +139,15 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
                 {"CopySubfolders", true}
             });
 
-            var factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
             MakeSutAndParse(factoryStub);
 
             taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenConfigWithProjectWithJobAndLinkTask__WhenParsing__JobShouldHaveTask() {
+        public void GivenConfigWithProjectWithJobAndLinkTask__WhenParsing__JobShouldHaveTask()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -144,18 +155,19 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var jobStub = new JobStub();
-            var taskDummy = new TaskDummy();
-            var factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
+            JobStub jobStub = new JobStub();
+            TaskDummy taskDummy = new TaskDummy();
+            BuildComponentFactoryStub factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
 
             MakeSutAndParse(factoryStub);
 
-            var actualTask = jobStub.Tasks.First();
+            ITask actualTask = jobStub.Tasks.First();
             Assert.AreEqual(taskDummy, actualTask);
         }
 
         [TestMethod]
-        public void GivenConfigWithProjectWithJobAndCleanTask__WhenParsing__JobShouldHaveTask() {
+        public void GivenConfigWithProjectWithJobAndCleanTask__WhenParsing__JobShouldHaveTask()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -163,18 +175,19 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var jobStub = new JobStub();
-            var taskDummy = new TaskDummy();
-            var factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
+            JobStub jobStub = new JobStub();
+            TaskDummy taskDummy = new TaskDummy();
+            BuildComponentFactoryStub factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
 
             MakeSutAndParse(factoryStub);
 
-            var actualTask = jobStub.Tasks.First();
+            ITask actualTask = jobStub.Tasks.First();
             Assert.AreEqual(taskDummy, actualTask);
         }
 
         [TestMethod]
-        public void GivenConfigWithCleanTask__WhenParsing__TaskShouldBeConfiguredCorrectly() {
+        public void GivenConfigWithCleanTask__WhenParsing__TaskShouldBeConfiguredCorrectly()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -182,18 +195,20 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object> {
-                {"Path", "path"},
+            TaskBuilderMock taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object>
+            {
+                {"Path", "path"}
             });
 
-            var factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
             MakeSutAndParse(factoryStub);
 
             taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenConfigWithProjectWithJobAndRunProcessTask__WhenParsing__JobShouldHaveTask() {
+        public void GivenConfigWithProjectWithJobAndRunProcessTask__WhenParsing__JobShouldHaveTask()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -201,18 +216,19 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var jobStub = new JobStub();
-            var taskDummy = new TaskDummy();
-            var factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
+            JobStub jobStub = new JobStub();
+            TaskDummy taskDummy = new TaskDummy();
+            BuildComponentFactoryStub factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
 
             MakeSutAndParse(factoryStub);
 
-            var actualTask = jobStub.Tasks.First();
+            ITask actualTask = jobStub.Tasks.First();
             Assert.AreEqual(taskDummy, actualTask);
         }
 
         [TestMethod]
-        public void GivenConfigWithProjectRunProcessTaskWithSettings__WhenParsing__TaskShouldBeConfiguredCorrectly() {
+        public void GivenConfigWithProjectRunProcessTaskWithSettings__WhenParsing__TaskShouldBeConfiguredCorrectly()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -224,21 +240,23 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object> {
+            TaskBuilderMock taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object>
+            {
                 {"ExecutablePath", "echo"},
                 {"Arguments", "Hello World"},
                 {"WorkingDirectory", "sub/dir"},
                 {"AllowedToFail", true}
             });
 
-            var factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
             MakeSutAndParse(factoryStub);
 
             taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenConfigWithProjectWithJobAndCreateSteamWorkshopItemTask__WhenParsing__JobShouldHaveTask() {
+        public void GivenConfigWithProjectWithJobAndCreateSteamWorkshopItemTask__WhenParsing__JobShouldHaveTask()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -254,19 +272,20 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var jobStub = new JobStub();
-            var taskDummy = new TaskDummy();
-            var factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
+            JobStub jobStub = new JobStub();
+            TaskDummy taskDummy = new TaskDummy();
+            BuildComponentFactoryStub factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
 
             MakeSutAndParse(factoryStub);
 
-            var actualTask = jobStub.Tasks.First();
+            ITask actualTask = jobStub.Tasks.First();
             Assert.AreEqual(taskDummy, actualTask);
         }
 
         [TestMethod]
         public void
-            GivenConfigWithCreateSteamWorkshopItemTask_WithoutTags__WhenParsing__TaskShouldBeConfiguredWithGivenSettings() {
+            GivenConfigWithCreateSteamWorkshopItemTask_WithoutTags__WhenParsing__TaskShouldBeConfiguredWithGivenSettings()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -281,7 +300,8 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object> {
+            TaskBuilderMock taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object>
+            {
                 {"AppId", (uint) 32470},
                 {"Title", "my-test-item"},
                 {"DescriptionFilePath", "path/to/description"},
@@ -290,19 +310,21 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
                 {"Language", "English"}
             });
 
-            var factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
             MakeSutAndParse(factoryStub);
 
             taskBuilderMock.Verify();
         }
 
         /// <summary>
-        /// For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't do deep comparisons.
-        /// Instead we're querying the "Tags" key manually
+        ///     For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't
+        ///     do deep comparisons.
+        ///     Instead we're querying the "Tags" key manually
         /// </summary>
         [TestMethod]
         public void
-            GivenConfigWithCreateSteamWorkshopItemTask_WithTags__WhenParsing__TaskShouldBeConfiguredWithGivenTags() {
+            GivenConfigWithCreateSteamWorkshopItemTask_WithTags__WhenParsing__TaskShouldBeConfiguredWithGivenTags()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -318,18 +340,19 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var taskBuilderSpy = new TaskBuilderSpy();
+            TaskBuilderSpy taskBuilderSpy = new TaskBuilderSpy();
 
-            var factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderSpy};
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderSpy};
             MakeSutAndParse(factoryStub);
 
-            var actual = taskBuilderSpy["Tags"];
+            object actual = taskBuilderSpy["Tags"];
             Assert.IsInstanceOfType(actual, typeof(IEnumerable<string>));
             CollectionAssert.AreEquivalent(ExpectedTags, ((IEnumerable<string>) actual).ToArray());
         }
 
         [TestMethod]
-        public void GivenConfigWithProjectWithJobAndUpdateSteamWorkshopItemTask__WhenParsing__JobShouldHaveTask() {
+        public void GivenConfigWithProjectWithJobAndUpdateSteamWorkshopItemTask__WhenParsing__JobShouldHaveTask()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -344,19 +367,20 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var jobStub = new JobStub();
-            var taskDummy = new TaskDummy();
-            var factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
+            JobStub jobStub = new JobStub();
+            TaskDummy taskDummy = new TaskDummy();
+            BuildComponentFactoryStub factoryStub = MakeBuildComponentFactoryStub(jobStub, taskDummy);
 
             MakeSutAndParse(factoryStub);
 
-            var actualTask = jobStub.Tasks.First();
+            ITask actualTask = jobStub.Tasks.First();
             Assert.AreEqual(taskDummy, actualTask);
         }
 
         [TestMethod]
         public void
-            GivenConfigWithUpdateSteamWorkshopItemTask_WithoutTags__WhenParsing__TaskShouldBeConfiguredWithGivenSettings() {
+            GivenConfigWithUpdateSteamWorkshopItemTask_WithoutTags__WhenParsing__TaskShouldBeConfiguredWithGivenSettings()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -372,29 +396,32 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object> {
+            TaskBuilderMock taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object>
+            {
                 {"AppId", (uint) 32470},
                 {"ItemId", (ulong) 1234},
                 {"Title", "my-test-item"},
                 {"DescriptionFilePath", "path/to/description"},
                 {"ItemFolderPath", "path/to/folder"},
                 {"Visibility", WorkshopItemVisibility.Private},
-                {"Language", "English"},
+                {"Language", "English"}
             });
 
-            var factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
             MakeSutAndParse(factoryStub);
 
             taskBuilderMock.Verify();
         }
 
         /// <summary>
-        /// For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't do deep comparisons.
-        /// Instead we're querying the "Tags" key manually
+        ///     For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't
+        ///     do deep comparisons.
+        ///     Instead we're querying the "Tags" key manually
         /// </summary>
         [TestMethod]
         public void
-            GivenConfigWithUpdateSteamWorkshopItemTask_WithTags__WhenParsing__TaskShouldBeConfiguredWithGivenTags() {
+            GivenConfigWithUpdateSteamWorkshopItemTask_WithTags__WhenParsing__TaskShouldBeConfiguredWithGivenTags()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -411,18 +438,19 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var taskBuilderMock = new TaskBuilderSpy();
+            TaskBuilderSpy taskBuilderMock = new TaskBuilderSpy();
 
-            var factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
             MakeSutAndParse(factoryStub);
 
-            var actual = taskBuilderMock["Tags"];
+            object actual = taskBuilderMock["Tags"];
             Assert.IsInstanceOfType(actual, typeof(IEnumerable<string>));
             CollectionAssert.AreEquivalent(ExpectedTags, ((IEnumerable<string>) actual).ToArray());
         }
 
         [TestMethod]
-        public void GivenJobWithMultipleTasks__WhenCallingParse__JobShouldHaveAllTasks() {
+        public void GivenJobWithMultipleTasks__WhenCallingParse__JobShouldHaveAllTasks()
+        {
             const string lua = @"
                 local p = project('test')
                 local j = p:add_job('test-job')
@@ -430,35 +458,41 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             ";
             _mockFileData.TextContents = lua;
 
-            var jobStub = new JobStub();
+            JobStub jobStub = new JobStub();
             ITask[] expectedTasks = {new TaskDummy(), new TaskDummy()};
-            var factoryStub = new BuildComponentFactoryStub {
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub
+            {
                 Job = jobStub,
-                TaskBuilder = new IteratingTaskBuilderStub {
+                TaskBuilder = new IteratingTaskBuilderStub
+                {
                     Tasks = expectedTasks.ToList()
                 }
             };
 
             MakeSutAndParse(factoryStub);
 
-            var actualTasks = jobStub.Tasks;
+            List<ITask> actualTasks = jobStub.Tasks;
             CollectionAssert.AreEqual(expectedTasks, actualTasks);
         }
 
-        private static BuildComponentFactoryStub MakeBuildComponentFactoryStub(JobDummy job, TaskDummy task = null) {
-            var factoryStub = new BuildComponentFactoryStub {
+        private static BuildComponentFactoryStub MakeBuildComponentFactoryStub(JobDummy job, TaskDummy task = null)
+        {
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub
+            {
                 Project = new ProjectStub(),
                 Job = job,
-                TaskBuilder = new TaskBuilderStub {
+                TaskBuilder = new TaskBuilderStub
+                {
                     Task = task ?? new TaskDummy()
                 }
             };
             return factoryStub;
         }
 
-        private IEnumerable<IProject> MakeSutAndParse(IBuildComponentFactory factoryStub) {
-            var sut = new LuaBuildConfigParser(_luaMockFileParser, factoryStub);
-            var projects = sut.Parse(Path);
+        private IEnumerable<IProject> MakeSutAndParse(IBuildComponentFactory factoryStub)
+        {
+            LuaBuildConfigParser sut = new LuaBuildConfigParser(_luaMockFileParser, factoryStub);
+            IEnumerable<IProject> projects = sut.Parse(Path);
             return projects;
         }
     }

--- a/eawx-build-test/Configuration/Lua/v1/LuaCleanTaskTest.cs
+++ b/eawx-build-test/Configuration/Lua/v1/LuaCleanTaskTest.cs
@@ -3,17 +3,21 @@ using EawXBuild.Configuration.Lua.v1;
 using EawXBuildTest.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
     [TestClass]
-    public class LuaCleanTaskTest {
+    public class LuaCleanTaskTest
+    {
         [TestMethod]
-        public void GivenLuaCleanTask__ShouldCallTaskBuilderWithPath() {
+        public void GivenLuaCleanTask__ShouldCallTaskBuilderWithPath()
+        {
             const string path = "folder/file";
-            var taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object> {
+            TaskBuilderMock taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object>
+            {
                 {"Path", path}
             });
 
-            var sut = new LuaCleanTask(taskBuilderMock, path);
+            LuaCleanTask sut = new LuaCleanTask(taskBuilderMock, path);
 
             taskBuilderMock.Verify();
         }

--- a/eawx-build-test/Configuration/Lua/v1/LuaCopyTaskTest.cs
+++ b/eawx-build-test/Configuration/Lua/v1/LuaCopyTaskTest.cs
@@ -4,85 +4,96 @@ using EawXBuild.Configuration.Lua.v1;
 using EawXBuildTest.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
     [TestClass]
-    public class LuaCopyTaskTest {
-        private TaskBuilderMock _taskBuilderMock;
+    public class LuaCopyTaskTest
+    {
         private const string Source = "original.txt";
         private const string Target = "copy.txt";
+        private TaskBuilderMock _taskBuilderMock;
 
 
         [TestMethod]
-        public void GivenLuaCopyTaskWithSourceAndDestination__ShouldBuildTaskWithCorrectSettings() {
+        public void GivenLuaCopyTaskWithSourceAndDestination__ShouldBuildTaskWithCorrectSettings()
+        {
             InitTaskBuilderMock();
 
-            var sut = new LuaCopyTask(_taskBuilderMock, "original.txt", "copy.txt");
+            LuaCopyTask sut = new LuaCopyTask(_taskBuilderMock, "original.txt", "copy.txt");
 
             _taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenLuaCopyTask__WhenCallingOverwrite__ShouldBuildTaskWithOverwrite() {
+        public void GivenLuaCopyTask__WhenCallingOverwrite__ShouldBuildTaskWithOverwrite()
+        {
             InitTaskBuilderMock(new Dictionary<string, object> {{"AlwaysOverwrite", true}});
 
-            var sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
+            LuaCopyTask sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
             sut.overwrite(true);
 
             _taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenLuaCopyTask__WhenCallingOverwrite__ShouldReturnItself() {
+        public void GivenLuaCopyTask__WhenCallingOverwrite__ShouldReturnItself()
+        {
             InitTaskBuilderMock(new Dictionary<string, object> {{"AlwaysOverwrite", true}});
 
-            var sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
-            var actual = sut.overwrite(true);
+            LuaCopyTask sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
+            LuaCopyTask actual = sut.overwrite(true);
 
             Assert.AreSame(sut, actual);
         }
 
         [TestMethod]
-        public void GivenLuaCopyTask__WhenCallingPattern__ShouldBuildTaskWithPattern() {
+        public void GivenLuaCopyTask__WhenCallingPattern__ShouldBuildTaskWithPattern()
+        {
             InitTaskBuilderMock(new Dictionary<string, object> {{"CopyFileByPattern", "*.xml"}});
 
-            var sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
+            LuaCopyTask sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
             sut.pattern("*.xml");
 
             _taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenLuaCopyTask__WhenCallingPattern__ShouldReturnItself() {
+        public void GivenLuaCopyTask__WhenCallingPattern__ShouldReturnItself()
+        {
             InitTaskBuilderMock(new Dictionary<string, object> {{"CopyFileByPattern", "*.xml"}});
 
-            var sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
-            var actual = sut.pattern("*.xml");
+            LuaCopyTask sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
+            LuaCopyTask actual = sut.pattern("*.xml");
 
             Assert.AreSame(sut, actual);
         }
 
         [TestMethod]
-        public void GivenLuaCopyTask__WhenCallingRecursive__ShouldBuildTaskWithRecursive() {
+        public void GivenLuaCopyTask__WhenCallingRecursive__ShouldBuildTaskWithRecursive()
+        {
             InitTaskBuilderMock(new Dictionary<string, object> {{"CopySubfolders", true}});
 
-            var sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
+            LuaCopyTask sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
             sut.recursive(true);
 
             _taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenLuaCopyTask__WhenCallingRecursive__ShouldReturnItself() {
+        public void GivenLuaCopyTask__WhenCallingRecursive__ShouldReturnItself()
+        {
             InitTaskBuilderMock(new Dictionary<string, object> {{"CopySubfolders", true}});
 
-            var sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
-            var actual = sut.recursive(true);
+            LuaCopyTask sut = new LuaCopyTask(_taskBuilderMock, Source, Target);
+            LuaCopyTask actual = sut.recursive(true);
 
             Assert.AreSame(sut, actual);
         }
 
-        private void InitTaskBuilderMock(Dictionary<string, object> expectedConfig = null) {
-            var expectedEntries = new Dictionary<string, object> {
+        private void InitTaskBuilderMock(Dictionary<string, object> expectedConfig = null)
+        {
+            Dictionary<string, object> expectedEntries = new Dictionary<string, object>
+            {
                 {"CopyFromPath", Source},
                 {"CopyToPath", Target}
             };

--- a/eawx-build-test/Configuration/Lua/v1/LuaCreateSteamWorkshopItemTaskTest.cs
+++ b/eawx-build-test/Configuration/Lua/v1/LuaCreateSteamWorkshopItemTaskTest.cs
@@ -6,10 +6,11 @@ using EawXBuildTest.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NLua;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
     [TestClass]
-    public class LuaCreateSteamWorkshopItemTaskTest {
-        private static readonly string[] ExpectedTags = {"EAW", "FOC"};
+    public class LuaCreateSteamWorkshopItemTaskTest
+    {
         private const long AppIdAsLong = 32740;
         private const uint AppIdAsUInt = (uint) AppIdAsLong;
         private const string Title = "My Awesome title";
@@ -19,73 +20,82 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
 
         private const string LuaPublicVisibility = "public";
         private const string LuaPrivateVisibility = "private";
+        private static readonly string[] ExpectedTags = {"EAW", "FOC"};
 
         [TestMethod]
         public void
-            GivenLuaCreateSteamWorkshopItemTaskWithConfigTable_With_PublicVisibility__OnCreation__ShouldConfigureTask() {
-            var taskBuilderMock = CreateTaskBuilderMock(WorkshopItemVisibility.Public);
+            GivenLuaCreateSteamWorkshopItemTaskWithConfigTable_With_PublicVisibility__OnCreation__ShouldConfigureTask()
+        {
+            TaskBuilderMock taskBuilderMock = CreateTaskBuilderMock(WorkshopItemVisibility.Public);
 
-            using var luaInterpreter = new NLua.Lua();
+            using NLua.Lua luaInterpreter = new NLua.Lua();
             PushVisibilityTable(luaInterpreter);
-            var table = CreateFullConfigurationTableWithoutTags(luaInterpreter, LuaPublicVisibility);
-            var sut = new LuaCreateSteamWorkshopItemTask(taskBuilderMock, table);
+            LuaTable table = CreateFullConfigurationTableWithoutTags(luaInterpreter, LuaPublicVisibility);
+            LuaCreateSteamWorkshopItemTask sut = new LuaCreateSteamWorkshopItemTask(taskBuilderMock, table);
 
             taskBuilderMock.Verify();
         }
 
         [TestMethod]
         public void
-            GivenLuaCreateSteamWorkshopItemTaskWithConfigTable_With_PrivateVisibility__OnCreation__ShouldConfigureTask() {
-            var taskBuilderMock = CreateTaskBuilderMock(WorkshopItemVisibility.Private);
+            GivenLuaCreateSteamWorkshopItemTaskWithConfigTable_With_PrivateVisibility__OnCreation__ShouldConfigureTask()
+        {
+            TaskBuilderMock taskBuilderMock = CreateTaskBuilderMock(WorkshopItemVisibility.Private);
 
-            using var luaInterpreter = new NLua.Lua();
+            using NLua.Lua luaInterpreter = new NLua.Lua();
             PushVisibilityTable(luaInterpreter);
-            var table = CreateFullConfigurationTableWithoutTags(luaInterpreter, LuaPrivateVisibility);
-            var sut = new LuaCreateSteamWorkshopItemTask(taskBuilderMock, table);
+            LuaTable table = CreateFullConfigurationTableWithoutTags(luaInterpreter, LuaPrivateVisibility);
+            LuaCreateSteamWorkshopItemTask sut = new LuaCreateSteamWorkshopItemTask(taskBuilderMock, table);
 
             taskBuilderMock.Verify();
         }
 
         /// <summary>
-        /// For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't do deep comparisons.
-        /// Instead we're querying the "Tags" key manually
+        ///     For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't
+        ///     do deep comparisons.
+        ///     Instead we're querying the "Tags" key manually
         /// </summary>
         [TestMethod]
         public void
-            GivenLuaCreateSteamWorkshopItemTaskWithConfigTable_With_Tags__OnCreation__ShouldConfigureTaskWithTags() {
-            var taskBuilderSpy = new TaskBuilderSpy();
-            using var luaInterpreter = new NLua.Lua();
-            var table = CreateConfigurationTableWithOnlyTags(luaInterpreter);
+            GivenLuaCreateSteamWorkshopItemTaskWithConfigTable_With_Tags__OnCreation__ShouldConfigureTaskWithTags()
+        {
+            TaskBuilderSpy taskBuilderSpy = new TaskBuilderSpy();
+            using NLua.Lua luaInterpreter = new NLua.Lua();
+            LuaTable table = CreateConfigurationTableWithOnlyTags(luaInterpreter);
 
-            var sut = new LuaCreateSteamWorkshopItemTask(taskBuilderSpy, table);
+            LuaCreateSteamWorkshopItemTask sut = new LuaCreateSteamWorkshopItemTask(taskBuilderSpy, table);
 
-            var actual = taskBuilderSpy["Tags"];
+            object actual = taskBuilderSpy["Tags"];
             Assert.IsInstanceOfType(actual, typeof(IEnumerable<string>));
             CollectionAssert.AreEquivalent(ExpectedTags, ((IEnumerable<string>) actual).ToArray());
         }
 
         /// <summary>
-        /// For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't do deep comparisons.
-        /// Instead we're querying the "Tags" key manually
+        ///     For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't
+        ///     do deep comparisons.
+        ///     Instead we're querying the "Tags" key manually
         /// </summary>
         [TestMethod]
         public void
-            GivenLuaCreateSteamWorkshopItemTaskWithConfigTable_With_DuplicateTags__OnCreation__ShouldConfigureTaskWithoutDuplicateTags() {
-            var taskBuilderSpy = new TaskBuilderSpy();
-            using var luaInterpreter = new NLua.Lua();
+            GivenLuaCreateSteamWorkshopItemTaskWithConfigTable_With_DuplicateTags__OnCreation__ShouldConfigureTaskWithoutDuplicateTags()
+        {
+            TaskBuilderSpy taskBuilderSpy = new TaskBuilderSpy();
+            using NLua.Lua luaInterpreter = new NLua.Lua();
 
-            var table = CreateConfigurationTableWithOnlyTags(luaInterpreter);
+            LuaTable table = CreateConfigurationTableWithOnlyTags(luaInterpreter);
             table["2"] = "EAW";
 
-            var sut = new LuaCreateSteamWorkshopItemTask(taskBuilderSpy, table);
+            LuaCreateSteamWorkshopItemTask sut = new LuaCreateSteamWorkshopItemTask(taskBuilderSpy, table);
 
-            var actual = taskBuilderSpy["Tags"];
+            object actual = taskBuilderSpy["Tags"];
             Assert.IsInstanceOfType(actual, typeof(IEnumerable<string>));
             CollectionAssert.AreEquivalent(ExpectedTags, ((IEnumerable<string>) actual).ToArray());
         }
 
-        private static TaskBuilderMock CreateTaskBuilderMock(WorkshopItemVisibility visibility) {
-            return new TaskBuilderMock(new Dictionary<string, object> {
+        private static TaskBuilderMock CreateTaskBuilderMock(WorkshopItemVisibility visibility)
+        {
+            return new TaskBuilderMock(new Dictionary<string, object>
+            {
                 {"AppId", AppIdAsUInt},
                 {"Title", Title},
                 {"DescriptionFilePath", DescriptionFilePath},
@@ -95,18 +105,21 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             });
         }
 
-        private static LuaTable CreateConfigurationTableWithOnlyTags(NLua.Lua luaInterpreter) {
-            var table = NLuaUtilities.MakeLuaTable(luaInterpreter, "the_table");
-            var tags = NLuaUtilities.MakeLuaTable(luaInterpreter, "tag_table");
+        private static LuaTable CreateConfigurationTableWithOnlyTags(NLua.Lua luaInterpreter)
+        {
+            LuaTable table = NLuaUtilities.MakeLuaTable(luaInterpreter, "the_table");
+            LuaTable tags = NLuaUtilities.MakeLuaTable(luaInterpreter, "tag_table");
             tags[0] = "EAW";
             tags[1] = "FOC";
             table["tags"] = tags;
             return table;
         }
 
-        private static LuaTable CreateFullConfigurationTableWithoutTags(NLua.Lua luaInterpreter, string luaVisibility) {
-            var table = NLuaUtilities.MakeLuaTable(luaInterpreter, "the_table");
-            var visibility = (WorkshopItemVisibility) luaInterpreter.GetObjectFromPath("visibility." + luaVisibility);
+        private static LuaTable CreateFullConfigurationTableWithoutTags(NLua.Lua luaInterpreter, string luaVisibility)
+        {
+            LuaTable table = NLuaUtilities.MakeLuaTable(luaInterpreter, "the_table");
+            WorkshopItemVisibility visibility =
+                (WorkshopItemVisibility) luaInterpreter.GetObjectFromPath("visibility." + luaVisibility);
 
             table["app_id"] = AppIdAsLong;
             table["title"] = Title;
@@ -118,9 +131,10 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             return table;
         }
 
-        private static void PushVisibilityTable(NLua.Lua luaInterpreter) {
+        private static void PushVisibilityTable(NLua.Lua luaInterpreter)
+        {
             luaInterpreter.NewTable("visibility");
-            var luaTable = luaInterpreter.GetTable("visibility");
+            LuaTable luaTable = luaInterpreter.GetTable("visibility");
             luaTable["private"] = WorkshopItemVisibility.Private;
             luaTable["public"] = WorkshopItemVisibility.Public;
         }

--- a/eawx-build-test/Configuration/Lua/v1/LuaJobTest.cs
+++ b/eawx-build-test/Configuration/Lua/v1/LuaJobTest.cs
@@ -2,37 +2,42 @@ using EawXBuild.Configuration.Lua.v1;
 using EawXBuild.Core;
 using EawXBuildTest.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NLua;
 using NLua.Exceptions;
 using static EawXBuildTest.Configuration.Lua.v1.NLuaUtilities;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
     [TestClass]
-    public class LuaJobTest {
+    public class LuaJobTest
+    {
         [TestMethod]
-        public void GivenLuaJobWithJob__WhenCallingAddTask__ContainedJobShouldHaveTask() {
-            var jobStub = new JobStub();
-            var taskDummy = new TaskDummy();
+        public void GivenLuaJobWithJob__WhenCallingAddTask__ContainedJobShouldHaveTask()
+        {
+            JobStub jobStub = new JobStub();
+            TaskDummy taskDummy = new TaskDummy();
 
-            var sut = new LuaJob(jobStub);
-            var luaTaskStub = new LuaTaskStub {Task = taskDummy};
+            LuaJob sut = new LuaJob(jobStub);
+            LuaTaskStub luaTaskStub = new LuaTaskStub {Task = taskDummy};
             sut.add_task(luaTaskStub);
 
             CollectionAssert.Contains(jobStub.Tasks, taskDummy);
         }
 
         [TestMethod]
-        public void GivenLuaJobWithJob__WhenCallingAddTasks__ContainedJobShouldHaveAllTasks() {
-            using var luaInterpreter = new NLua.Lua();
+        public void GivenLuaJobWithJob__WhenCallingAddTasks__ContainedJobShouldHaveAllTasks()
+        {
+            using NLua.Lua luaInterpreter = new NLua.Lua();
 
-            var firstTaskDummy = new TaskDummy();
-            var secondTaskDummy = new TaskDummy();
+            TaskDummy firstTaskDummy = new TaskDummy();
+            TaskDummy secondTaskDummy = new TaskDummy();
 
-            var taskTable = MakeLuaTable(luaInterpreter, "taskTable");
+            LuaTable taskTable = MakeLuaTable(luaInterpreter, "taskTable");
             taskTable[1] = new LuaTaskStub {Task = firstTaskDummy};
             taskTable[2] = new LuaTaskStub {Task = secondTaskDummy};
 
-            var jobStub = new JobStub();
-            var sut = new LuaJob(jobStub);
+            JobStub jobStub = new JobStub();
+            LuaJob sut = new LuaJob(jobStub);
             sut.add_tasks(taskTable);
 
             ITask[] expectedTasks = {firstTaskDummy, secondTaskDummy};
@@ -41,13 +46,14 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
 
         [TestMethod]
         [ExpectedException(typeof(LuaScriptException))]
-        public void GivenLuaJobWithJob__WhenCallingAddTasksWithNonTaskValue__ShouldThrowLuaScriptException() {
-            using var luaInterpreter = new NLua.Lua();
-            var invalidTable = MakeLuaTable(luaInterpreter, "invalidTable");
+        public void GivenLuaJobWithJob__WhenCallingAddTasksWithNonTaskValue__ShouldThrowLuaScriptException()
+        {
+            using NLua.Lua luaInterpreter = new NLua.Lua();
+            LuaTable invalidTable = MakeLuaTable(luaInterpreter, "invalidTable");
             invalidTable[1] = "Invalid";
 
-            var jobStub = new JobStub();
-            var sut = new LuaJob(jobStub);
+            JobStub jobStub = new JobStub();
+            LuaJob sut = new LuaJob(jobStub);
             sut.add_tasks(invalidTable);
         }
     }

--- a/eawx-build-test/Configuration/Lua/v1/LuaMockFileSystemParser.cs
+++ b/eawx-build-test/Configuration/Lua/v1/LuaMockFileSystemParser.cs
@@ -2,31 +2,38 @@ using System.IO.Abstractions.TestingHelpers;
 using EawXBuild.Configuration.Lua.v1;
 using NLua;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
-    public class LuaMockFileSystemParser : ILuaParser {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
+    public class LuaMockFileSystemParser : ILuaParser
+    {
         private readonly MockFileSystem _fileSystem;
 
-        public LuaMockFileSystemParser(MockFileSystem fileSystem) {
+        public LuaMockFileSystemParser(MockFileSystem fileSystem)
+        {
             _fileSystem = fileSystem;
         }
 
         public NLua.Lua Lua { get; } = new NLua.Lua();
 
-        public LuaTable NewTable(string fullPath) {
+        public LuaTable NewTable(string fullPath)
+        {
             Lua.NewTable(fullPath);
             return Lua.GetTable(fullPath);
         }
 
-        public void RegisterObject(object obj) {
+        public void RegisterObject(object obj)
+        {
             LuaRegistrationHelper.TaggedInstanceMethods(Lua, obj);
         }
 
-        public void DoFile(string fileName) {
-            var fileData = _fileSystem.GetFile(fileName);
+        public void DoFile(string fileName)
+        {
+            MockFileData fileData = _fileSystem.GetFile(fileName);
             Lua.DoString(fileData.TextContents);
         }
 
-        public void Dispose() {
+        public void Dispose()
+        {
             Lua?.Dispose();
         }
     }

--- a/eawx-build-test/Configuration/Lua/v1/LuaProjectTest.cs
+++ b/eawx-build-test/Configuration/Lua/v1/LuaProjectTest.cs
@@ -1,47 +1,55 @@
 using System.Linq;
 using EawXBuild.Configuration.Lua.v1;
+using EawXBuild.Core;
 using EawXBuildTest.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
     [TestClass]
-    public class LuaProjectTest {
+    public class LuaProjectTest
+    {
         [TestMethod]
-        public void GivenLuaProjectWithName__WhenGettingProject__ProjectShouldHaveName() {
-            var factoryStub = new BuildComponentFactoryStub();
-            var sut = new LuaProject("TestProject", factoryStub);
+        public void GivenLuaProjectWithName__WhenGettingProject__ProjectShouldHaveName()
+        {
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub();
+            LuaProject sut = new LuaProject("TestProject", factoryStub);
 
-            var actual = sut.Project.Name;
+            string actual = sut.Project.Name;
             Assert.AreEqual("TestProject", actual);
         }
 
         [TestMethod]
-        public void GivenLuaProjectWithJob__WhenGettingProject__ProjectShouldHaveJob() {
-            var jobStub = new JobStub();
-            var factoryStub = new BuildComponentFactoryStub {
+        public void GivenLuaProjectWithJob__WhenGettingProject__ProjectShouldHaveJob()
+        {
+            JobStub jobStub = new JobStub();
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub
+            {
                 Project = new ProjectStub(),
                 Job = jobStub
             };
 
-            var sut = new LuaProject("TestProject", factoryStub);
+            LuaProject sut = new LuaProject("TestProject", factoryStub);
             sut.add_job("test-job");
 
-            var actual = sut.Project as ProjectStub;
-            var actualJob = actual?.Jobs.First();
+            ProjectStub actual = sut.Project as ProjectStub;
+            IJob actualJob = actual?.Jobs.First();
             Assert.AreSame(jobStub, actualJob);
             Assert.AreEqual("test-job", actualJob?.Name);
         }
 
         [TestMethod]
-        public void GivenLuaProject__WhenAddingJob__ShouldReturnLuaJob() {
-            var jobStub = new JobStub();
-            var factoryStub = new BuildComponentFactoryStub {
+        public void GivenLuaProject__WhenAddingJob__ShouldReturnLuaJob()
+        {
+            JobStub jobStub = new JobStub();
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub
+            {
                 Project = new ProjectStub(),
                 Job = jobStub
             };
 
-            var sut = new LuaProject("TestProject", factoryStub);
-            var actual = sut.add_job("test-job");
+            LuaProject sut = new LuaProject("TestProject", factoryStub);
+            LuaJob actual = sut.add_job("test-job");
             Assert.IsInstanceOfType(actual, typeof(LuaJob));
         }
     }

--- a/eawx-build-test/Configuration/Lua/v1/LuaRunProcessTaskTest.cs
+++ b/eawx-build-test/Configuration/Lua/v1/LuaRunProcessTaskTest.cs
@@ -3,85 +3,96 @@ using EawXBuild.Configuration.Lua.v1;
 using EawXBuildTest.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
     [TestClass]
-    public class LuaRunProcessTaskTest {
+    public class LuaRunProcessTaskTest
+    {
         private const string Path = "echo";
         private TaskBuilderMock _taskBuilderMock;
 
         [TestInitialize]
-        public void SetUp() {
-            _taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object> {
+        public void SetUp()
+        {
+            _taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object>
+            {
                 {"ExecutablePath", Path}
             });
         }
 
         [TestMethod]
-        public void GivenLuaRunProcessTask__ShouldCallTaskBuilderWithExecutablePath() {
-            var sut = new LuaRunProcessTask(_taskBuilderMock, Path);
+        public void GivenLuaRunProcessTask__ShouldCallTaskBuilderWithExecutablePath()
+        {
+            LuaRunProcessTask sut = new LuaRunProcessTask(_taskBuilderMock, Path);
 
             _taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenLuaRunProcessTask__WhenCallingArguments__ShouldCallTaskBuilderWithArguments() {
+        public void GivenLuaRunProcessTask__WhenCallingArguments__ShouldCallTaskBuilderWithArguments()
+        {
             const string args = "hello world";
             _taskBuilderMock.AddExpectedEntry("Arguments", args);
 
-            var sut = new LuaRunProcessTask(_taskBuilderMock, Path);
+            LuaRunProcessTask sut = new LuaRunProcessTask(_taskBuilderMock, Path);
             sut.arguments(args);
 
             _taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenLuaRunProcessTask__WhenCallingArguments__ShouldReturnItself() {
+        public void GivenLuaRunProcessTask__WhenCallingArguments__ShouldReturnItself()
+        {
             const string args = "hello world";
 
-            var sut = new LuaRunProcessTask(_taskBuilderMock, Path);
-            var actual = sut.arguments(args);
+            LuaRunProcessTask sut = new LuaRunProcessTask(_taskBuilderMock, Path);
+            LuaRunProcessTask actual = sut.arguments(args);
 
             Assert.AreSame(sut, actual);
         }
 
         [TestMethod]
-        public void GivenLuaRunProcessTask__WhenCallingWorkingDirectory__ShouldCallTaskBuilderWithWorkingDirectory() {
+        public void GivenLuaRunProcessTask__WhenCallingWorkingDirectory__ShouldCallTaskBuilderWithWorkingDirectory()
+        {
             const string workingDirectory = "another/dir";
             _taskBuilderMock.AddExpectedEntry("WorkingDirectory", workingDirectory);
 
-            var sut = new LuaRunProcessTask(_taskBuilderMock, Path);
+            LuaRunProcessTask sut = new LuaRunProcessTask(_taskBuilderMock, Path);
             sut.working_directory(workingDirectory);
 
             _taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenLuaRunProcessTask__WhenCallingWorkingDirectory__ShouldReturnItself() {
+        public void GivenLuaRunProcessTask__WhenCallingWorkingDirectory__ShouldReturnItself()
+        {
             const string workingDirectory = "another/dir";
 
-            var sut = new LuaRunProcessTask(_taskBuilderMock, Path);
-            var actual = sut.working_directory(workingDirectory);
+            LuaRunProcessTask sut = new LuaRunProcessTask(_taskBuilderMock, Path);
+            LuaRunProcessTask actual = sut.working_directory(workingDirectory);
 
             Assert.AreSame(sut, actual);
         }
 
         [TestMethod]
-        public void GivenLuaRunProcessTask__WhenCallingAllowedToFail__ShouldCallTaskBuilderWithWorkingDirectory() {
+        public void GivenLuaRunProcessTask__WhenCallingAllowedToFail__ShouldCallTaskBuilderWithWorkingDirectory()
+        {
             const bool allowedToFail = true;
             _taskBuilderMock.AddExpectedEntry("AllowedToFail", allowedToFail);
 
-            var sut = new LuaRunProcessTask(_taskBuilderMock, Path);
+            LuaRunProcessTask sut = new LuaRunProcessTask(_taskBuilderMock, Path);
             sut.allowed_to_fail(allowedToFail);
 
             _taskBuilderMock.Verify();
         }
 
         [TestMethod]
-        public void GivenLuaRunProcessTask__WhenCallingAllowedToFail__ShouldReturnItself() {
+        public void GivenLuaRunProcessTask__WhenCallingAllowedToFail__ShouldReturnItself()
+        {
             const bool allowedToFail = true;
 
-            var sut = new LuaRunProcessTask(_taskBuilderMock, Path);
-            var actual = sut.allowed_to_fail(allowedToFail);
+            LuaRunProcessTask sut = new LuaRunProcessTask(_taskBuilderMock, Path);
+            LuaRunProcessTask actual = sut.allowed_to_fail(allowedToFail);
 
             Assert.AreSame(sut, actual);
         }

--- a/eawx-build-test/Configuration/Lua/v1/LuaTaskStub.cs
+++ b/eawx-build-test/Configuration/Lua/v1/LuaTaskStub.cs
@@ -1,8 +1,10 @@
 using EawXBuild.Configuration.Lua.v1;
 using EawXBuild.Core;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
-    public class LuaTaskStub : ILuaTask {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
+    public class LuaTaskStub : ILuaTask
+    {
         public ITask Task { get; set; }
     }
 }

--- a/eawx-build-test/Configuration/Lua/v1/LuaUpdateSteamWorkshopItemTaskTest.cs
+++ b/eawx-build-test/Configuration/Lua/v1/LuaUpdateSteamWorkshopItemTaskTest.cs
@@ -6,10 +6,11 @@ using EawXBuildTest.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NLua;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
     [TestClass]
-    public class LuaUpdateSteamWorkshopItemTaskTest {
-        private static readonly string[] ExpectedTags = {"EAW", "FOC"};
+    public class LuaUpdateSteamWorkshopItemTaskTest
+    {
         private const long AppIdAsLong = 32740;
         private const uint AppIdAsUInt = (uint) AppIdAsLong;
         private const long ItemIdAsLong = 1234;
@@ -21,83 +22,93 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
 
         private const string LuaPublicVisibility = "public";
         private const string LuaPrivateVisibility = "private";
+        private static readonly string[] ExpectedTags = {"EAW", "FOC"};
 
         [TestMethod]
         public void
-            GivenLuaUpdateSteamWorkshopItemTaskWithConfigTable_With_PublicVisibility__OnCreation__ShouldConfigureTask() {
-            var taskBuilderMock = CreateTaskBuilderMock(WorkshopItemVisibility.Public);
+            GivenLuaUpdateSteamWorkshopItemTaskWithConfigTable_With_PublicVisibility__OnCreation__ShouldConfigureTask()
+        {
+            TaskBuilderMock taskBuilderMock = CreateTaskBuilderMock(WorkshopItemVisibility.Public);
 
-            using var luaInterpreter = new NLua.Lua();
+            using NLua.Lua luaInterpreter = new NLua.Lua();
             PushVisibilityTable(luaInterpreter);
-            var table = CreateConfigurationTable(luaInterpreter, LuaPublicVisibility);
-            var sut = new LuaUpdateSteamWorkshopItemTask(taskBuilderMock, table);
+            LuaTable table = CreateConfigurationTable(luaInterpreter, LuaPublicVisibility);
+            LuaUpdateSteamWorkshopItemTask sut = new LuaUpdateSteamWorkshopItemTask(taskBuilderMock, table);
 
             taskBuilderMock.Verify();
         }
 
         [TestMethod]
         public void
-            GivenLuaUpdateSteamWorkshopItemTaskWithConfigTable_With_PrivateVisibility__OnCreation__ShouldConfigureTask() {
-            var taskBuilderMock = CreateTaskBuilderMock(WorkshopItemVisibility.Private);
+            GivenLuaUpdateSteamWorkshopItemTaskWithConfigTable_With_PrivateVisibility__OnCreation__ShouldConfigureTask()
+        {
+            TaskBuilderMock taskBuilderMock = CreateTaskBuilderMock(WorkshopItemVisibility.Private);
 
-            using var luaInterpreter = new NLua.Lua();
+            using NLua.Lua luaInterpreter = new NLua.Lua();
             PushVisibilityTable(luaInterpreter);
-            var table = CreateConfigurationTable(luaInterpreter, LuaPrivateVisibility);
-            var sut = new LuaUpdateSteamWorkshopItemTask(taskBuilderMock, table);
+            LuaTable table = CreateConfigurationTable(luaInterpreter, LuaPrivateVisibility);
+            LuaUpdateSteamWorkshopItemTask sut = new LuaUpdateSteamWorkshopItemTask(taskBuilderMock, table);
 
             taskBuilderMock.Verify();
         }
 
         /// <summary>
-        /// For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't do deep comparisons.
-        /// Instead we're querying the "Tags" key manually
+        ///     For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't
+        ///     do deep comparisons.
+        ///     Instead we're querying the "Tags" key manually
         /// </summary>
         [TestMethod]
         public void
-            GivenLuaUpdateSteamWorkshopItemTaskWithConfigTable_With_Tags__OnCreation__ShouldConfigureTaskWithTags() {
-            var taskBuilderSpy = new TaskBuilderSpy();
-            using var luaInterpreter = new NLua.Lua();
-            var table = CreateConfigurationTableWithOnlyTags(luaInterpreter);
+            GivenLuaUpdateSteamWorkshopItemTaskWithConfigTable_With_Tags__OnCreation__ShouldConfigureTaskWithTags()
+        {
+            TaskBuilderSpy taskBuilderSpy = new TaskBuilderSpy();
+            using NLua.Lua luaInterpreter = new NLua.Lua();
+            LuaTable table = CreateConfigurationTableWithOnlyTags(luaInterpreter);
 
-            var sut = new LuaUpdateSteamWorkshopItemTask(taskBuilderSpy, table);
+            LuaUpdateSteamWorkshopItemTask sut = new LuaUpdateSteamWorkshopItemTask(taskBuilderSpy, table);
 
-            var actual = taskBuilderSpy["Tags"];
+            object actual = taskBuilderSpy["Tags"];
             Assert.IsInstanceOfType(actual, typeof(IEnumerable<string>));
             CollectionAssert.AreEquivalent(ExpectedTags, ((IEnumerable<string>) actual).ToArray());
         }
 
         /// <summary>
-        /// For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't do deep comparisons.
-        /// Instead we're querying the "Tags" key manually
+        ///     For this test we're not using the TaskBuilderMock, because it uses CollectionAssert under the hood, which doesn't
+        ///     do deep comparisons.
+        ///     Instead we're querying the "Tags" key manually
         /// </summary>
         [TestMethod]
         public void
-            GivenLuaUpdateSteamWorkshopItemTaskWithConfigTable_With_DuplicateTags__OnCreation__ShouldConfigureTaskWithoutDuplicateTags() {
-            var taskBuilderSpy = new TaskBuilderSpy();
-            using var luaInterpreter = new NLua.Lua();
+            GivenLuaUpdateSteamWorkshopItemTaskWithConfigTable_With_DuplicateTags__OnCreation__ShouldConfigureTaskWithoutDuplicateTags()
+        {
+            TaskBuilderSpy taskBuilderSpy = new TaskBuilderSpy();
+            using NLua.Lua luaInterpreter = new NLua.Lua();
 
-            var table = CreateConfigurationTableWithOnlyTags(luaInterpreter);
+            LuaTable table = CreateConfigurationTableWithOnlyTags(luaInterpreter);
             table["2"] = "EAW";
 
-            var sut = new LuaUpdateSteamWorkshopItemTask(taskBuilderSpy, table);
+            LuaUpdateSteamWorkshopItemTask sut = new LuaUpdateSteamWorkshopItemTask(taskBuilderSpy, table);
 
-            var actual = taskBuilderSpy["Tags"];
+            object actual = taskBuilderSpy["Tags"];
             Assert.IsInstanceOfType(actual, typeof(IEnumerable<string>));
             CollectionAssert.AreEquivalent(ExpectedTags, ((IEnumerable<string>) actual).ToArray());
         }
 
-        private static LuaTable CreateConfigurationTableWithOnlyTags(NLua.Lua luaInterpreter) {
-            var table = NLuaUtilities.MakeLuaTable(luaInterpreter, "the_table");
-            var tags = NLuaUtilities.MakeLuaTable(luaInterpreter, "tag_table");
+        private static LuaTable CreateConfigurationTableWithOnlyTags(NLua.Lua luaInterpreter)
+        {
+            LuaTable table = NLuaUtilities.MakeLuaTable(luaInterpreter, "the_table");
+            LuaTable tags = NLuaUtilities.MakeLuaTable(luaInterpreter, "tag_table");
             tags[0] = "EAW";
             tags[1] = "FOC";
             table["tags"] = tags;
             return table;
         }
 
-        private static LuaTable CreateConfigurationTable(NLua.Lua luaInterpreter, string luaVisibility) {
-            var table = NLuaUtilities.MakeLuaTable(luaInterpreter, "the_table");
-            var visibility = (WorkshopItemVisibility) luaInterpreter.GetObjectFromPath("visibility." + luaVisibility);
+        private static LuaTable CreateConfigurationTable(NLua.Lua luaInterpreter, string luaVisibility)
+        {
+            LuaTable table = NLuaUtilities.MakeLuaTable(luaInterpreter, "the_table");
+            WorkshopItemVisibility visibility =
+                (WorkshopItemVisibility) luaInterpreter.GetObjectFromPath("visibility." + luaVisibility);
             table["app_id"] = AppIdAsLong;
             table["item_id"] = ItemIdAsLong;
             table["title"] = Title;
@@ -108,8 +119,10 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             return table;
         }
 
-        private static TaskBuilderMock CreateTaskBuilderMock(WorkshopItemVisibility visibility) {
-            return new TaskBuilderMock(new Dictionary<string, object> {
+        private static TaskBuilderMock CreateTaskBuilderMock(WorkshopItemVisibility visibility)
+        {
+            return new TaskBuilderMock(new Dictionary<string, object>
+            {
                 {"AppId", AppIdAsUInt},
                 {"ItemId", ItemIdAsULong},
                 {"Title", Title},
@@ -120,9 +133,10 @@ namespace EawXBuildTest.Configuration.Lua.v1 {
             });
         }
 
-        private static void PushVisibilityTable(NLua.Lua luaInterpreter) {
+        private static void PushVisibilityTable(NLua.Lua luaInterpreter)
+        {
             luaInterpreter.NewTable("visibility");
-            var luaTable = luaInterpreter.GetTable("visibility");
+            LuaTable luaTable = luaInterpreter.GetTable("visibility");
             luaTable["private"] = WorkshopItemVisibility.Private;
             luaTable["public"] = WorkshopItemVisibility.Public;
         }

--- a/eawx-build-test/Configuration/Lua/v1/NLuaUtilities.cs
+++ b/eawx-build-test/Configuration/Lua/v1/NLuaUtilities.cs
@@ -1,10 +1,13 @@
 using NLua;
 
-namespace EawXBuildTest.Configuration.Lua.v1 {
-    public static class NLuaUtilities {
-        public static LuaTable MakeLuaTable(NLua.Lua luaInterpreter, string tableName) {
+namespace EawXBuildTest.Configuration.Lua.v1
+{
+    public static class NLuaUtilities
+    {
+        public static LuaTable MakeLuaTable(NLua.Lua luaInterpreter, string tableName)
+        {
             luaInterpreter.NewTable(tableName);
-            var taskTable = luaInterpreter.GetTable(tableName);
+            LuaTable taskTable = luaInterpreter.GetTable(tableName);
             return taskTable;
         }
     }

--- a/eawx-build-test/Configuration/Xml/v1/BuildConfigParserTest.cs
+++ b/eawx-build-test/Configuration/Xml/v1/BuildConfigParserTest.cs
@@ -8,16 +8,19 @@ using EawXBuild.Core;
 using EawXBuildTest.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Configuration.Xml.v1 {
+namespace EawXBuildTest.Configuration.Xml.v1
+{
     [TestClass]
-    public class BuildConfigParserTest {
+    public class BuildConfigParserTest
+    {
         private const string Path = "MyXml.xml";
 
         private MockFileSystem _fileSystem;
         private MockFileData _mockFileData;
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             _mockFileData = new MockFileData(string.Empty);
             _fileSystem = new MockFileSystem();
             _fileSystem.AddFile(Path, _mockFileData);
@@ -25,7 +28,8 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
         [TestMethod]
         public void
-            GivenXmlWithWrongConfigVersion__WhenCallingParse__ShouldThrowException() {
+            GivenXmlWithWrongConfigVersion__WhenCallingParse__ShouldThrowException()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.1"" 
@@ -47,12 +51,14 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
             _mockFileData.TextContents = xml;
             const string exceptionMessage =
                 "The value of the 'ConfigVersion' attribute does not equal its fixed value.";
-            var factoryStub = new BuildComponentFactoryStub {Project = new ProjectStub()};
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
-            try {
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub {Project = new ProjectStub()};
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            try
+            {
                 sut.Parse(Path);
             }
-            catch (Exception e) {
+            catch (Exception e)
+            {
                 Assert.AreEqual(typeof(InvalidOperationException), e.GetType());
                 Assert.AreEqual(typeof(XmlSchemaValidationException), e.InnerException.GetType());
                 Assert.AreEqual(exceptionMessage, e.InnerException.Message);
@@ -60,7 +66,8 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
         }
 
         [TestMethod]
-        public void GivenXmlWithSingleProject__WhenCallingParse__ShouldReturnArrayWithMatchingProject() {
+        public void GivenXmlWithSingleProject__WhenCallingParse__ShouldReturnArrayWithMatchingProject()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -82,18 +89,19 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             const string projectName = "TestProject";
 
-            var factoryStub = new BuildComponentFactoryStub {Project = new ProjectStub()};
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub {Project = new ProjectStub()};
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
 
-            var projects = sut.Parse(Path);
+            IEnumerable<IProject> projects = sut.Parse(Path);
 
-            var actual = projects.ToList()[0] as ProjectStub;
-            var actualName = actual?.Name;
+            ProjectStub actual = projects.ToList()[0] as ProjectStub;
+            string actualName = actual?.Name;
             AssertProjectNameEquals(projectName, actualName);
         }
 
         [TestMethod]
-        public void GivenXmlWithSingleProjectAndJob__WhenCallingParse__ProjectShouldHaveMatchingJob() {
+        public void GivenXmlWithSingleProjectAndJob__WhenCallingParse__ProjectShouldHaveMatchingJob()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -115,18 +123,20 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             const string jobName = "TestJob";
 
-            var factoryStub = new BuildComponentFactoryStub {Project = new ProjectStub(), Job = new JobStub()};
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub
+                {Project = new ProjectStub(), Job = new JobStub()};
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
 
-            var projects = sut.Parse(Path);
+            IEnumerable<IProject> projects = sut.Parse(Path);
 
-            var actualProject = (ProjectStub) projects.ToList()[0];
-            var actualJob = actualProject.Jobs[0];
+            ProjectStub actualProject = (ProjectStub) projects.ToList()[0];
+            IJob actualJob = actualProject.Jobs[0];
             AssertJobNameEquals(jobName, actualJob);
         }
 
         [TestMethod]
-        public void GivenProjectWithJobAndCopyTask__WhenCallingParse__ShouldRequestTaskBuilderForCorrectType() {
+        public void GivenProjectWithJobAndCopyTask__WhenCallingParse__ShouldRequestTaskBuilderForCorrectType()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -153,18 +163,19 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             _mockFileData.TextContents = xml;
 
-            var factorySpy = new BuildComponentFactorySpy();
-            var sut = new XmlBuildConfigParser(_fileSystem, factorySpy);
+            BuildComponentFactorySpy factorySpy = new BuildComponentFactorySpy();
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factorySpy);
 
             sut.Parse(Path);
 
-            var expected = "Copy";
+            string expected = "Copy";
             Assert.AreEqual(expected, factorySpy.ActualTaskTypeName,
                 $"Should have requested TaskBuilder for {expected}, but got {factorySpy.ActualTaskTypeName}");
         }
 
         [TestMethod]
-        public void GivenProjectWithJobAndCopyTask__WhenCallingParse__ShouldConfigureTaskWithBuilder() {
+        public void GivenProjectWithJobAndCopyTask__WhenCallingParse__ShouldConfigureTaskWithBuilder()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -191,7 +202,8 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             _mockFileData.TextContents = xml;
 
-            var taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object> {
+            TaskBuilderMock taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object>
+            {
                 {"Id", "TestTask"},
                 {"Name", "TestTask"},
                 {"CopyFromPath", "path/to/source"},
@@ -201,8 +213,8 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
                 {"AlwaysOverwrite", false}
             });
 
-            var factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub {TaskBuilder = taskBuilderMock};
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
 
             sut.Parse(Path);
 
@@ -210,7 +222,8 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
         }
 
         [TestMethod]
-        public void GivenProjectWithJobAndCopyTask__WhenCallingParse__ShouldAddTaskToJob() {
+        public void GivenProjectWithJobAndCopyTask__WhenCallingParse__ShouldAddTaskToJob()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -237,10 +250,11 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             _mockFileData.TextContents = xml;
 
-            var jobStub = new JobStub();
-            var taskBuilderStub = new TaskBuilderStub();
-            var factoryStub = new BuildComponentFactoryStub {Job = jobStub, TaskBuilder = taskBuilderStub};
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            JobStub jobStub = new JobStub();
+            TaskBuilderStub taskBuilderStub = new TaskBuilderStub();
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub
+                {Job = jobStub, TaskBuilder = taskBuilderStub};
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
 
             sut.Parse(Path);
 
@@ -248,7 +262,8 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
         }
 
         [TestMethod]
-        public void GivenGlobalCopyTaskAndReferenceInProjectJob__WhenCallingParse__ShouldAddTaskToJob() {
+        public void GivenGlobalCopyTaskAndReferenceInProjectJob__WhenCallingParse__ShouldAddTaskToJob()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -279,10 +294,11 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             _mockFileData.TextContents = xml;
 
-            var jobStub = new JobStub();
-            var taskBuilderStub = new TaskBuilderStub();
-            var factoryStub = new BuildComponentFactoryStub {Job = jobStub, TaskBuilder = taskBuilderStub};
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            JobStub jobStub = new JobStub();
+            TaskBuilderStub taskBuilderStub = new TaskBuilderStub();
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub
+                {Job = jobStub, TaskBuilder = taskBuilderStub};
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
 
             sut.Parse(Path);
 
@@ -291,7 +307,8 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
         [TestMethod]
         public void
-            GivenTwoGlobalTasksAndReferenceToSecondInProjectJob__WhenCallingParse__ShouldBuildSecondGlobalTask() {
+            GivenTwoGlobalTasksAndReferenceToSecondInProjectJob__WhenCallingParse__ShouldBuildSecondGlobalTask()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -330,8 +347,9 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             _mockFileData.TextContents = xml;
 
-            var jobStub = new JobStub();
-            var taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object> {
+            JobStub jobStub = new JobStub();
+            TaskBuilderMock taskBuilderMock = new TaskBuilderMock(new Dictionary<string, object>
+            {
                 {"Id", "ExpectedTask"},
                 {"Name", "ExpectedTask"},
                 {"CopyFromPath", "path/to/source"},
@@ -341,8 +359,9 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
                 {"AlwaysOverwrite", false}
             });
 
-            var factoryStub = new BuildComponentFactoryStub {Job = jobStub, TaskBuilder = taskBuilderMock};
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub
+                {Job = jobStub, TaskBuilder = taskBuilderMock};
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
 
             sut.Parse(Path);
 
@@ -350,7 +369,8 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
         }
 
         [TestMethod]
-        public void GivenProjectWithJobAndTwoTasks__WhenCallingParse__ShouldAddBothTasksToJob() {
+        public void GivenProjectWithJobAndTwoTasks__WhenCallingParse__ShouldAddBothTasksToJob()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -385,16 +405,17 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             _mockFileData.TextContents = xml;
 
-            var jobStub = new JobStub();
-            var firstTask = new TaskDummy();
-            var secondTask = new TaskDummy();
+            JobStub jobStub = new JobStub();
+            TaskDummy firstTask = new TaskDummy();
+            TaskDummy secondTask = new TaskDummy();
 
-            var taskBuilderStub = new IteratingTaskBuilderStub();
+            IteratingTaskBuilderStub taskBuilderStub = new IteratingTaskBuilderStub();
             taskBuilderStub.Tasks.Add(firstTask);
             taskBuilderStub.Tasks.Add(secondTask);
 
-            var factoryStub = new BuildComponentFactoryStub {Job = jobStub, TaskBuilder = taskBuilderStub};
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub
+                {Job = jobStub, TaskBuilder = taskBuilderStub};
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
 
             sut.Parse(Path);
 
@@ -404,7 +425,8 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
 
         [TestMethod]
-        public void GivenProjectWithTwoJobs__WhenCallingParse__ShouldAddBothJobsToProject() {
+        public void GivenProjectWithTwoJobs__WhenCallingParse__ShouldAddBothJobsToProject()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -427,14 +449,15 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             _mockFileData.TextContents = xml;
 
-            var expectedJobs = new List<IJob> {new JobStub(), new JobStub()};
-            var projectStub = new ProjectStub();
-            var factoryStub = new JobIteratingBuildComponentFactoryStub {
+            List<IJob> expectedJobs = new List<IJob> {new JobStub(), new JobStub()};
+            ProjectStub projectStub = new ProjectStub();
+            JobIteratingBuildComponentFactoryStub factoryStub = new JobIteratingBuildComponentFactoryStub
+            {
                 Project = projectStub,
                 Jobs = expectedJobs
             };
 
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
 
             sut.Parse(Path);
 
@@ -442,7 +465,8 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
         }
 
         [TestMethod]
-        public void GivenBuildConfigWithTwoProjects__WhenCallingParse__ShouldReturnBothProjects() {
+        public void GivenBuildConfigWithTwoProjects__WhenCallingParse__ShouldReturnBothProjects()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -468,14 +492,15 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             _mockFileData.TextContents = xml;
 
-            var expectedProjects = new List<IProject> {new ProjectDummy(), new ProjectDummy()};
-            var factoryStub = new ProjectIteratingBuildComponentFactoryStub() {
+            List<IProject> expectedProjects = new List<IProject> {new ProjectDummy(), new ProjectDummy()};
+            ProjectIteratingBuildComponentFactoryStub factoryStub = new ProjectIteratingBuildComponentFactoryStub
+            {
                 Projects = expectedProjects
             };
 
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
 
-            var projects = sut.Parse(Path);
+            IEnumerable<IProject> projects = sut.Parse(Path);
 
             CollectionAssert.AreEqual(expectedProjects, projects.ToList());
         }
@@ -519,33 +544,37 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
                                     </Project>
                                   </Projects>
                                 </eaw-ci:BuildConfiguration>", false)]
-        public void GivenConfig__TestIsValidConfiguration__IsExpected(string xmlContent, bool expected) {
+        public void GivenConfig__TestIsValidConfiguration__IsExpected(string xmlContent, bool expected)
+        {
             _mockFileData.TextContents = xmlContent;
-            var sut = new XmlBuildConfigParser(_fileSystem, null);
-            var actual = sut.TestIsValidConfiguration(Path);
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, null);
+            bool actual = sut.TestIsValidConfiguration(Path);
             Assert.AreEqual(expected, actual);
         }
 
         [TestMethod]
-        public void GivenNullConfig__TestIsValidConfiguration__ReturnsFalse() {
-            var sut = new XmlBuildConfigParser(_fileSystem, null);
-            var actual = sut.TestIsValidConfiguration(null);
+        public void GivenNullConfig__TestIsValidConfiguration__ReturnsFalse()
+        {
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, null);
+            bool actual = sut.TestIsValidConfiguration(null);
             Assert.IsFalse(actual);
         }
 
         [TestMethod]
-        public void GivenEmptyConfig__TestIsValidConfiguration__ReturnsFalse() {
+        public void GivenEmptyConfig__TestIsValidConfiguration__ReturnsFalse()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>";
             _mockFileData.TextContents = xml;
-            var sut = new XmlBuildConfigParser(_fileSystem, null);
-            var actual = sut.TestIsValidConfiguration(Path);
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, null);
+            bool actual = sut.TestIsValidConfiguration(Path);
             Assert.IsFalse(actual);
         }
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
         public void
-            GivenProjectWithJobAndTaskReferenceToNonExistingGlobalTask__WhenCallingParse__ShouldThrowInvalidOperationException() {
+            GivenProjectWithJobAndTaskReferenceToNonExistingGlobalTask__WhenCallingParse__ShouldThrowInvalidOperationException()
+        {
             const string xml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
                                 <eaw-ci:BuildConfiguration
                                   ConfigVersion=""1.0.0"" 
@@ -569,24 +598,27 @@ namespace EawXBuildTest.Configuration.Xml.v1 {
 
             _mockFileData.TextContents = xml;
 
-            var factoryStub = new BuildComponentFactoryStub();
-            var sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
+            BuildComponentFactoryStub factoryStub = new BuildComponentFactoryStub();
+            XmlBuildConfigParser sut = new XmlBuildConfigParser(_fileSystem, factoryStub);
 
             sut.Parse(Path);
         }
 
 
-        private static void AssertJobHasExpectedTask(JobStub jobStub, ITask element) {
+        private static void AssertJobHasExpectedTask(JobStub jobStub, ITask element)
+        {
             CollectionAssert.Contains(jobStub.Tasks, element,
                 "Should Job should have expected task, but does not.");
         }
 
-        private static void AssertProjectNameEquals(string projectName, string actualName) {
+        private static void AssertProjectNameEquals(string projectName, string actualName)
+        {
             Assert.AreEqual(projectName, actualName,
                 $"Should return Project with name {projectName}, but was {actualName}");
         }
 
-        private static void AssertJobNameEquals(string jobName, IJob actualJob) {
+        private static void AssertJobNameEquals(string jobName, IJob actualJob)
+        {
             Assert.AreEqual(jobName, actualJob.Name, $"Job name should be {jobName}, but was {actualJob.Name}");
         }
     }

--- a/eawx-build-test/Core/BuildComponentFactoryTestDoubles.cs
+++ b/eawx-build-test/Core/BuildComponentFactoryTestDoubles.cs
@@ -1,51 +1,61 @@
 using System.Collections.Generic;
 using EawXBuild.Core;
 
-namespace EawXBuildTest.Core {
-    public class BuildComponentFactoryStub : IBuildComponentFactory {
+namespace EawXBuildTest.Core
+{
+    public class BuildComponentFactoryStub : IBuildComponentFactory
+    {
         public IProject Project { get; set; } = new ProjectDummy();
 
         public JobDummy Job { get; set; } = new JobDummy();
 
         public ITaskBuilder TaskBuilder { get; set; } = new TaskBuilderDummy();
 
-        public virtual IProject MakeProject() {
+        public virtual IProject MakeProject()
+        {
             return Project;
         }
 
-        public virtual IJob MakeJob(string name) {
+        public virtual IJob MakeJob(string name)
+        {
             Job.Name = name;
             return Job;
         }
 
-        public virtual ITaskBuilder Task(string taskTypeName) {
+        public virtual ITaskBuilder Task(string taskTypeName)
+        {
             return TaskBuilder;
         }
     }
 
-    public class JobIteratingBuildComponentFactoryStub : IBuildComponentFactory {
+    public class JobIteratingBuildComponentFactoryStub : IBuildComponentFactory
+    {
         private IEnumerator<IJob> _enumerator;
 
         public IEnumerable<IJob> Jobs { get; set; }
 
         public IProject Project { get; set; }
 
-        public IJob MakeJob(string name) {
+        public IJob MakeJob(string name)
+        {
             if (_enumerator == null) _enumerator = Jobs.GetEnumerator();
             _enumerator.MoveNext();
             return _enumerator.Current;
         }
 
-        public IProject MakeProject() {
+        public IProject MakeProject()
+        {
             return Project;
         }
 
-        public ITaskBuilder Task(string taskTypeName) {
+        public ITaskBuilder Task(string taskTypeName)
+        {
             return new TaskBuilderStub();
         }
     }
 
-    public class ProjectIteratingBuildComponentFactoryStub : IBuildComponentFactory {
+    public class ProjectIteratingBuildComponentFactoryStub : IBuildComponentFactory
+    {
         private IEnumerator<IProject> _enumerator;
 
         public IEnumerable<IProject> Projects { get; set; }
@@ -54,25 +64,30 @@ namespace EawXBuildTest.Core {
 
         public ITaskBuilder TaskBuilder { get; set; } = new TaskBuilderDummy();
 
-        public IJob MakeJob(string name) {
+        public IJob MakeJob(string name)
+        {
             return Job;
         }
 
-        public IProject MakeProject() {
+        public IProject MakeProject()
+        {
             if (_enumerator == null) _enumerator = Projects.GetEnumerator();
             _enumerator.MoveNext();
             return _enumerator.Current;
         }
 
-        public ITaskBuilder Task(string taskTypeName) {
+        public ITaskBuilder Task(string taskTypeName)
+        {
             return TaskBuilder;
         }
     }
 
-    public class BuildComponentFactorySpy : BuildComponentFactoryStub {
+    public class BuildComponentFactorySpy : BuildComponentFactoryStub
+    {
         public string ActualTaskTypeName { get; private set; }
 
-        public override ITaskBuilder Task(string taskTypeName) {
+        public override ITaskBuilder Task(string taskTypeName)
+        {
             ActualTaskTypeName = taskTypeName;
             return TaskBuilder;
         }

--- a/eawx-build-test/Core/JobTest.cs
+++ b/eawx-build-test/Core/JobTest.cs
@@ -1,22 +1,18 @@
-using System;
-using System.Globalization;
-using System.IO;
-using System.IO.Abstractions.TestingHelpers;
-using System.Text;
 using EawXBuild.Core;
-using EawXBuildTest.Tasks;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Core {
+namespace EawXBuildTest.Core
+{
     [TestClass]
-    public class JobTest {
+    public class JobTest
+    {
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
-        public void GivenJobWithTwoTasks__WhenRunningJob__ShouldExecuteAllTasks() {
-            var sut = new Job("job");
-            var firstTask = new TaskSpy();
-            var secondTask = new TaskSpy();
+        public void GivenJobWithTwoTasks__WhenRunningJob__ShouldExecuteAllTasks()
+        {
+            Job sut = new Job("job");
+            TaskSpy firstTask = new TaskSpy();
+            TaskSpy secondTask = new TaskSpy();
             sut.AddTask(firstTask);
             sut.AddTask(secondTask);
 
@@ -26,7 +22,8 @@ namespace EawXBuildTest.Core {
             AssertTaskWasRun(secondTask);
         }
 
-        private static void AssertTaskWasRun(TaskSpy firstTask) {
+        private static void AssertTaskWasRun(TaskSpy firstTask)
+        {
             Assert.IsTrue(firstTask.WasRun, "Task should have been run, but wasn't.");
         }
     }

--- a/eawx-build-test/Core/JobTestDoubles.cs
+++ b/eawx-build-test/Core/JobTestDoubles.cs
@@ -2,41 +2,54 @@ using System;
 using System.Collections.Generic;
 using EawXBuild.Core;
 
-namespace EawXBuildTest.Core {
-    public class JobDummy : IJob {
+namespace EawXBuildTest.Core
+{
+    public class JobDummy : IJob
+    {
         public virtual string Name { get; set; }
 
-        public virtual void AddTask(ITask task) { }
+        public virtual void AddTask(ITask task)
+        {
+        }
 
-        public virtual void Run() { }
+        public virtual void Run()
+        {
+        }
     }
 
-    public class JobStub : JobDummy {
+    public class JobStub : JobDummy
+    {
         public List<ITask> Tasks { get; } = new List<ITask>();
 
         public override string Name { get; set; }
 
-        public override void AddTask(ITask task) {
+        public override void AddTask(ITask task)
+        {
             Tasks.Add(task);
         }
     }
 
-    public class JobSpy : JobStub {
+    public class JobSpy : JobStub
+    {
         public bool WasRun { get; private set; }
 
-        public override void Run() {
+        public override void Run()
+        {
             WasRun = true;
         }
     }
 
-    public class ExceptionThrowingJob : JobDummy {
+    public class ExceptionThrowingJob : JobDummy
+    {
         private readonly string _exceptionMessage;
 
-        public ExceptionThrowingJob(string exceptionMessage) {
+        public ExceptionThrowingJob(string exceptionMessage)
+        {
             _exceptionMessage = exceptionMessage;
         }
 
-        public override void Run() {
+        public override void Run()
+        {
             throw new Exception(_exceptionMessage);
         }
     }

--- a/eawx-build-test/Core/ProjectTest.cs
+++ b/eawx-build-test/Core/ProjectTest.cs
@@ -1,26 +1,26 @@
-using System;
-using System.Globalization;
-using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 using EawXBuild.Core;
 using EawXBuild.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Core {
+namespace EawXBuildTest.Core
+{
     [TestClass]
-    public class ProjectTest {
+    public class ProjectTest
+    {
         private Project _sut;
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             _sut = new Project();
         }
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
-        public async System.Threading.Tasks.Task GivenProjectWithNamedJob__WhenCallingRunWithJobName__ShouldRunJob() {
-            var jobSpy = MakeJobSpy("job");
+        public async Task GivenProjectWithNamedJob__WhenCallingRunWithJobName__ShouldRunJob()
+        {
+            JobSpy jobSpy = MakeJobSpy("job");
             _sut.AddJob(jobSpy);
 
             await _sut.RunJobAsync("job");
@@ -30,11 +30,12 @@ namespace EawXBuildTest.Core {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
-        public async System.Threading.Tasks.Task
-            GivenProjectWithTwoJobs__WhenCallingRunWithJobName__ShouldOnlyRunWithMatchingName() {
-            var otherJob = MakeJobSpy("other");
+        public async Task
+            GivenProjectWithTwoJobs__WhenCallingRunWithJobName__ShouldOnlyRunWithMatchingName()
+        {
+            JobSpy otherJob = MakeJobSpy("other");
             _sut.AddJob(otherJob);
-            var expected = MakeJobSpy("job");
+            JobSpy expected = MakeJobSpy("job");
             _sut.AddJob(expected);
 
             await _sut.RunJobAsync("job");
@@ -45,10 +46,11 @@ namespace EawXBuildTest.Core {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
-        public void GivenProjectWithMultipleJobs__WhenCallingRunAll__AllJobsRan() {
-            var job1 = MakeJobSpy("job1");
+        public void GivenProjectWithMultipleJobs__WhenCallingRunAll__AllJobsRan()
+        {
+            JobSpy job1 = MakeJobSpy("job1");
             _sut.AddJob(job1);
-            var job2 = MakeJobSpy("job2");
+            JobSpy job2 = MakeJobSpy("job2");
             _sut.AddJob(job2);
 
             Task.WaitAll(_sut.RunAllJobsAsync().ToArray());
@@ -61,33 +63,38 @@ namespace EawXBuildTest.Core {
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
         [ExpectedException(typeof(JobNotFoundException))]
-        public void GivenProjectWithNoJobs__WhenCallingRunJob__ShouldThrowJobNotFoundException() {
+        public void GivenProjectWithNoJobs__WhenCallingRunJob__ShouldThrowJobNotFoundException()
+        {
             _sut.RunJobAsync("job");
         }
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
         [ExpectedException(typeof(DuplicateJobNameException))]
-        public void GivenProjectWithJob__WhenAddingJobWithSameName__ShouldThrowDuplicateJobNameException() {
-            var jobSpy = MakeJobSpy("job");
+        public void GivenProjectWithJob__WhenAddingJobWithSameName__ShouldThrowDuplicateJobNameException()
+        {
+            JobSpy jobSpy = MakeJobSpy("job");
 
             Assert.IsNotNull(_sut != null, nameof(_sut) + " != null");
             _sut.AddJob(jobSpy);
             _sut.AddJob(MakeJobSpy("job"));
         }
 
-        private static JobSpy MakeJobSpy(string name) {
-            var jobSpy = new JobSpy {Name = name};
+        private static JobSpy MakeJobSpy(string name)
+        {
+            JobSpy jobSpy = new JobSpy {Name = name};
 
             return jobSpy;
         }
 
-        private static void AssertJobWasRun(JobSpy jobSpy) {
+        private static void AssertJobWasRun(JobSpy jobSpy)
+        {
             Assert.IsNotNull(jobSpy != null, nameof(jobSpy) + " != null");
             Assert.IsTrue(jobSpy.WasRun, $"Job {jobSpy.Name} should have been run, but wasn't.");
         }
 
-        private static void AssertJobWasNotRun(JobSpy otherJob) {
+        private static void AssertJobWasNotRun(JobSpy otherJob)
+        {
             Assert.IsNotNull(otherJob != null, nameof(otherJob) + " != null");
             Assert.IsFalse(otherJob.WasRun, $"Should not have run Job {otherJob.Name}, but did.");
         }

--- a/eawx-build-test/Core/ProjectTestDoubles.cs
+++ b/eawx-build-test/Core/ProjectTestDoubles.cs
@@ -1,32 +1,42 @@
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using EawXBuild.Core;
-using Task = System.Threading.Tasks.Task;
 
-namespace EawXBuildTest.Core {
-    public class ProjectDummy : IProject {
+namespace EawXBuildTest.Core
+{
+    public class ProjectDummy : IProject
+    {
         public virtual string Name { get; set; }
 
-        public virtual void AddJob(IJob job) { }
+        public virtual void AddJob(IJob job)
+        {
+        }
 
-        public virtual Task RunJobAsync(string jobName) {
+        public virtual Task RunJobAsync(string jobName)
+        {
             return null;
         }
 
-        public List<Task> RunAllJobsAsync() {
-            throw new System.NotImplementedException();
+        public List<Task> RunAllJobsAsync()
+        {
+            throw new NotImplementedException();
         }
     }
 
-    public class ProjectStub : ProjectDummy {
+    public class ProjectStub : ProjectDummy
+    {
         public List<IJob> Jobs { get; } = new List<IJob>();
 
         public override string Name { get; set; }
 
-        public override void AddJob(IJob job) {
+        public override void AddJob(IJob job)
+        {
             Jobs.Add(job);
         }
 
-        public override Task RunJobAsync(string jobName) {
+        public override Task RunJobAsync(string jobName)
+        {
             return Task.CompletedTask;
         }
     }

--- a/eawx-build-test/Core/TaskBuilderTestDoubles.cs
+++ b/eawx-build-test/Core/TaskBuilderTestDoubles.cs
@@ -1,43 +1,49 @@
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using EawXBuild.Core;
-using Microsoft.VisualBasic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Core {
-    public class TaskBuilderDummy : ITaskBuilder {
-        public virtual ITaskBuilder With(string name, object value) {
+namespace EawXBuildTest.Core
+{
+    public class TaskBuilderDummy : ITaskBuilder
+    {
+        public virtual ITaskBuilder With(string name, object value)
+        {
             return this;
         }
 
-        public virtual ITask Build() {
+        public virtual ITask Build()
+        {
             return null;
         }
     }
 
-    public class TaskBuilderStub : TaskBuilderDummy {
+    public class TaskBuilderStub : TaskBuilderDummy
+    {
         public ITask Task { get; set; } = new TaskDummy();
 
-        public override ITask Build() {
+        public override ITask Build()
+        {
             return Task;
         }
     }
 
-    public class IteratingTaskBuilderStub : TaskBuilderDummy {
+    public class IteratingTaskBuilderStub : TaskBuilderDummy
+    {
         private IEnumerator<ITask> _enumerator;
         private List<ITask> _tasks = new List<ITask>();
 
-        public List<ITask> Tasks {
+        public List<ITask> Tasks
+        {
             get => _tasks;
-            set {
+            set
+            {
                 _tasks = value;
                 _enumerator = _tasks.GetEnumerator();
             }
         }
 
-        public override ITask Build() {
+        public override ITask Build()
+        {
             _enumerator ??= Tasks.GetEnumerator();
 
             _enumerator.MoveNext();
@@ -45,29 +51,35 @@ namespace EawXBuildTest.Core {
         }
     }
 
-    public class TaskBuilderSpy : TaskBuilderStub {
+    public class TaskBuilderSpy : TaskBuilderStub
+    {
         protected readonly Dictionary<string, object> _actualEntries = new Dictionary<string, object>();
 
-        public override ITaskBuilder With(string name, object value) {
+        public object this[string configurationOption] => _actualEntries[configurationOption];
+
+        public override ITaskBuilder With(string name, object value)
+        {
             _actualEntries.Add(name, value);
             return this;
         }
-
-        public object this[string configurationOption] => _actualEntries[configurationOption];
     }
 
-    public class TaskBuilderMock : TaskBuilderSpy {
+    public class TaskBuilderMock : TaskBuilderSpy
+    {
         private readonly Dictionary<string, object> _expectedEntries;
 
-        public TaskBuilderMock(Dictionary<string, object> expectedEntries) {
+        public TaskBuilderMock(Dictionary<string, object> expectedEntries)
+        {
             _expectedEntries = expectedEntries;
         }
 
-        public void AddExpectedEntry(string key, object value) {
+        public void AddExpectedEntry(string key, object value)
+        {
             _expectedEntries.Add(key, value);
         }
 
-        public void Verify() {
+        public void Verify()
+        {
             CollectionAssert.AreEquivalent(_expectedEntries, _actualEntries,
                 "Actual TaskBuilder configuration entries do not match expected ones");
         }

--- a/eawx-build-test/Core/TaskTestDoubles.cs
+++ b/eawx-build-test/Core/TaskTestDoubles.cs
@@ -1,17 +1,23 @@
 using EawXBuild.Core;
 
-namespace EawXBuildTest.Core {
-    public class TaskDummy : ITask {
+namespace EawXBuildTest.Core
+{
+    public class TaskDummy : ITask
+    {
         public string Id { get; set; }
         public string Name { get; set; }
 
-        public virtual void Run() { }
+        public virtual void Run()
+        {
+        }
     }
 
-    public class TaskSpy : TaskDummy {
+    public class TaskSpy : TaskDummy
+    {
         public bool WasRun { get; private set; }
 
-        public override void Run() {
+        public override void Run()
+        {
             WasRun = true;
         }
     }

--- a/eawx-build-test/EawXBuildApplicationLuaAcceptanceTest.cs
+++ b/eawx-build-test/EawXBuildApplicationLuaAcceptanceTest.cs
@@ -13,22 +13,26 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest {
+namespace EawXBuildTest
+{
     [TestClass]
-    public class EawXBuildApplicationLuaAcceptanceTest {
-        private readonly IFileSystem _fileSystem = new FileSystem();
+    public class EawXBuildApplicationLuaAcceptanceTest
+    {
         private const string LuaConfigFilePath = "eaw-ci.lua";
+        private readonly IFileSystem _fileSystem = new FileSystem();
         private IFileInfo _luaConfigFile;
         private ServiceCollection _services;
 
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             _services = ConfigureServices(_fileSystem);
         }
 
         [TestCleanup]
-        public void TearDown() {
+        public void TearDown()
+        {
             _luaConfigFile.Delete();
 
             if (_fileSystem.File.Exists("newfile.lua"))
@@ -36,7 +40,8 @@ namespace EawXBuildTest {
         }
 
         [TestMethod]
-        public void GivenConfig_With_OneProject_OneJob_And_CopyTask__WhenRunning__ShouldCopyToTargetLocation() {
+        public void GivenConfig_With_OneProject_OneJob_And_CopyTask__WhenRunning__ShouldCopyToTargetLocation()
+        {
             const string config = @"
             local proj = project('pid0')
             local job = proj:add_job('My-Job')
@@ -45,23 +50,26 @@ namespace EawXBuildTest {
 
             CreateConfigFile(config);
 
-            var options = new RunOptions {
+            RunOptions options = new RunOptions
+            {
                 BackendLua = true,
                 ConfigPath = "eaw-ci.lua",
                 ProjectName = "pid0",
                 JobName = "My-Job"
             };
 
-            var sut = new EawXBuildApplication(_services.BuildServiceProvider(), options);
+            EawXBuildApplication sut = new EawXBuildApplication(_services.BuildServiceProvider(), options);
 
             sut.Run();
 
-            var actual = _fileSystem.File.Exists("newfile.lua");
+            bool actual = _fileSystem.File.Exists("newfile.lua");
             Assert.IsTrue(actual);
         }
 
         [PlatformSpecificTestMethod("Linux", "OSX")]
-        public void GivenUnixLikeSystem_And_Config_With_OneProject_OneJob_And_RunProcessTask__WhenRunning__ShouldRunProcess() {
+        public void
+            GivenUnixLikeSystem_And_Config_With_OneProject_OneJob_And_RunProcessTask__WhenRunning__ShouldRunProcess()
+        {
             const string config = @"
             local proj = project('pid0')
             local job = proj:add_job('My-Job')
@@ -73,32 +81,35 @@ namespace EawXBuildTest {
 
             CreateConfigFile(config);
 
-            var stringBuilder = new StringBuilder();
+            StringBuilder stringBuilder = new StringBuilder();
             Console.SetOut(new StringWriter(stringBuilder));
 
-            var options = new RunOptions {
+            RunOptions options = new RunOptions
+            {
                 BackendLua = true,
                 ConfigPath = "eaw-ci.lua",
                 ProjectName = "pid0",
                 JobName = "My-Job"
             };
 
-            var sut = new EawXBuildApplication(_services.BuildServiceProvider(), options);
+            EawXBuildApplication sut = new EawXBuildApplication(_services.BuildServiceProvider(), options);
 
             sut.Run();
 
-            var actual = stringBuilder.ToString().Trim();
+            string actual = stringBuilder.ToString().Trim();
             Assert.AreEqual("Hello World", actual);
         }
 
-        private void CreateConfigFile(string content) {
-            using var stream = _fileSystem.File.CreateText(LuaConfigFilePath);
+        private void CreateConfigFile(string content)
+        {
+            using StreamWriter stream = _fileSystem.File.CreateText(LuaConfigFilePath);
             stream.Write(content);
             _luaConfigFile = _fileSystem.FileInfo.FromFileName(LuaConfigFilePath);
         }
 
-        private static ServiceCollection ConfigureServices(IFileSystem fileSystem, LogLevel logLevel = LogLevel.None) {
-            var services = new ServiceCollection();
+        private static ServiceCollection ConfigureServices(IFileSystem fileSystem, LogLevel logLevel = LogLevel.None)
+        {
+            ServiceCollection services = new ServiceCollection();
             services.AddLogging(builder => builder.AddConsole());
             services.Configure<LoggerFilterOptions>(options =>
                 options.AddFilter<ConsoleLoggerProvider>(null, logLevel));

--- a/eawx-build-test/EawXBuildApplicationLuaAcceptanceTest.cs
+++ b/eawx-build-test/EawXBuildApplicationLuaAcceptanceTest.cs
@@ -103,8 +103,8 @@ namespace EawXBuildTest {
             services.Configure<LoggerFilterOptions>(options =>
                 options.AddFilter<ConsoleLoggerProvider>(null, logLevel));
             services.AddTransient<IBuildComponentFactory, BuildComponentFactory>();
-            services.AddTransient<IIOService, IOService>(serviceProvider =>
-                new IOService(new FileSystem(), serviceProvider.GetRequiredService<ILoggerFactory>()));
+            services.AddTransient<IIOHelperService, IOHelperService>(serviceProvider =>
+                new IOHelperService(new FileSystem(), serviceProvider.GetRequiredService<ILoggerFactory>()));
             services.AddTransient<ILuaParser, NLuaParser>();
             return services;
         }

--- a/eawx-build-test/EawXBuildApplicationTest.cs
+++ b/eawx-build-test/EawXBuildApplicationTest.cs
@@ -26,7 +26,7 @@ namespace EawXBuildTest {
         public void GivenAValidServiceProvider__RequiredServicesResolveBackendCorrectly() {
             var app = new EawXBuildApplication(TestUtility.GetConfiguredServiceCollection().BuildServiceProvider(),
                 new RunOptions());
-            var xmlParser = app.GetXmlBuildConfigParserInternal(app.Services.GetService<IIOService>());
+            var xmlParser = app.GetXmlBuildConfigParserInternal(app.Services.GetService<IIOHelperService>());
             Assert.IsInstanceOfType(xmlParser, typeof(XmlBuildConfigParser));
             var luaParser = app.GetLuaBuildConfigParserInternal();
             Assert.IsInstanceOfType(luaParser, typeof(LuaBuildConfigParser));

--- a/eawx-build-test/EawXBuildApplicationTest.cs
+++ b/eawx-build-test/EawXBuildApplicationTest.cs
@@ -1,5 +1,6 @@
 using EawXBuild;
 using EawXBuild.Configuration.CLI;
+using EawXBuild.Configuration.FrontendAgnostic;
 using EawXBuild.Configuration.Lua.v1;
 using EawXBuild.Configuration.Xml.v1;
 using EawXBuild.Environment;
@@ -7,28 +8,36 @@ using EawXBuild.Services.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest {
+namespace EawXBuildTest
+{
     [TestClass]
-    public class EawXBuildApplicationTest {
+    public class EawXBuildApplicationTest
+    {
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
-        public void WhenCalledWithInvalidRunOptions__ThenCorrectError() {
-            var app = new EawXBuildApplication(TestUtility.GetConfiguredServiceCollection().BuildServiceProvider(),
-                new RunOptions {
+        public void WhenCalledWithInvalidRunOptions__ThenCorrectError()
+        {
+            EawXBuildApplication app = new EawXBuildApplication(
+                TestUtility.GetConfiguredServiceCollection().BuildServiceProvider(),
+                new RunOptions
+                {
                     BackendLua = false, BackendXml = false
                 });
-            var exitCode = app.Run();
+            ExitCode exitCode = app.Run();
             Assert.AreEqual(ExitCode.ExUsage, exitCode);
         }
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_HOLY)]
-        public void GivenAValidServiceProvider__RequiredServicesResolveBackendCorrectly() {
-            var app = new EawXBuildApplication(TestUtility.GetConfiguredServiceCollection().BuildServiceProvider(),
+        public void GivenAValidServiceProvider__RequiredServicesResolveBackendCorrectly()
+        {
+            EawXBuildApplication app = new EawXBuildApplication(
+                TestUtility.GetConfiguredServiceCollection().BuildServiceProvider(),
                 new RunOptions());
-            var xmlParser = app.GetXmlBuildConfigParserInternal(app.Services.GetService<IIOHelperService>());
+            IBuildConfigParser xmlParser =
+                app.GetXmlBuildConfigParserInternal(app.Services.GetService<IIOHelperService>());
             Assert.IsInstanceOfType(xmlParser, typeof(XmlBuildConfigParser));
-            var luaParser = app.GetLuaBuildConfigParserInternal();
+            IBuildConfigParser luaParser = app.GetLuaBuildConfigParserInternal();
             Assert.IsInstanceOfType(luaParser, typeof(LuaBuildConfigParser));
         }
     }

--- a/eawx-build-test/EawXBuildApplicationXmlAcceptanceTest.cs
+++ b/eawx-build-test/EawXBuildApplicationXmlAcceptanceTest.cs
@@ -118,8 +118,8 @@ namespace EawXBuildTest {
             services.Configure<LoggerFilterOptions>(options =>
                 options.AddFilter<ConsoleLoggerProvider>(null, logLevel));
             services.AddTransient<IBuildComponentFactory, BuildComponentFactory>();
-            services.AddTransient<IIOService, IOService>(serviceProvider =>
-                new IOService(new FileSystem(), serviceProvider.GetRequiredService<ILoggerFactory>()));
+            services.AddTransient<IIOHelperService, IOHelperService>(serviceProvider =>
+                new IOHelperService(new FileSystem(), serviceProvider.GetRequiredService<ILoggerFactory>()));
             return services;
         }
     }

--- a/eawx-build-test/EawXBuildApplicationXmlAcceptanceTest.cs
+++ b/eawx-build-test/EawXBuildApplicationXmlAcceptanceTest.cs
@@ -12,9 +12,11 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest {
+namespace EawXBuildTest
+{
     [TestClass]
-    public class EawXBuildXmlApplicationTest {
+    public class EawXBuildXmlApplicationTest
+    {
         private const string DefaultXml = @"<?xml version=""1.0"" encoding=""UTF-8""?>
 <eaw-ci:BuildConfiguration ConfigVersion=""1.0.0"" xmlns:eaw-ci=""eaw-ci"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xsi:schemaLocation=""eaw-ci eaw-ci.xsd "">
     <Projects>
@@ -46,35 +48,41 @@ namespace EawXBuildTest {
   <Arguments>Hello World</Arguments>
 </Task>";
 
+        private const string XmlConfigFilePath = "eaw-ci.xml";
+
 
         private readonly IFileSystem _fileSystem = new FileSystem();
-        private const string XmlConfigFilePath = "eaw-ci.xml";
-        private IFileInfo _xmlConfigFile;
         private ServiceCollection _services;
+        private IFileInfo _xmlConfigFile;
 
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             _services = ConfigureServices();
         }
 
         [TestCleanup]
-        public void TearDown() {
+        public void TearDown()
+        {
             _xmlConfigFile.Delete();
 
             if (_fileSystem.File.Exists("newfile.xml"))
                 _fileSystem.File.Delete("newfile.xml");
         }
 
-        private void CreateXmlConfigWithTask(string task) {
-            using var stream = _fileSystem.File.CreateText(XmlConfigFilePath);
+        private void CreateXmlConfigWithTask(string task)
+        {
+            using StreamWriter stream = _fileSystem.File.CreateText(XmlConfigFilePath);
             stream.Write(DefaultXml, task);
             _xmlConfigFile = _fileSystem.FileInfo.FromFileName(XmlConfigFilePath);
         }
 
         [TestMethod]
-        public void WhenRunningWith_OneProject_OneJob_And_CopyTask__ShouldCopyFileToTarget() {
-            var options = new RunOptions {
+        public void WhenRunningWith_OneProject_OneJob_And_CopyTask__ShouldCopyFileToTarget()
+        {
+            RunOptions options = new RunOptions
+            {
                 BackendXml = true,
                 ConfigPath = "eaw-ci.xml",
                 ProjectName = "pid0",
@@ -83,17 +91,19 @@ namespace EawXBuildTest {
 
             CreateXmlConfigWithTask(CopyTask);
 
-            var sut = new EawXBuildApplication(_services.BuildServiceProvider(), options);
+            EawXBuildApplication sut = new EawXBuildApplication(_services.BuildServiceProvider(), options);
 
             sut.Run();
 
-            var actual = _fileSystem.File.Exists("newfile.xml");
+            bool actual = _fileSystem.File.Exists("newfile.xml");
             Assert.IsTrue(actual);
         }
 
         [PlatformSpecificTestMethod("Linux", "OSX")]
-        public void GivenUnixLikeSystem__WhenRunningWith_OneProject_OneJob_And_RunProgramTask__ShouldRunProgram() {
-            var options = new RunOptions {
+        public void GivenUnixLikeSystem__WhenRunningWith_OneProject_OneJob_And_RunProgramTask__ShouldRunProgram()
+        {
+            RunOptions options = new RunOptions
+            {
                 BackendXml = true,
                 ConfigPath = "eaw-ci.xml",
                 ProjectName = "pid0",
@@ -101,19 +111,20 @@ namespace EawXBuildTest {
             };
 
             CreateXmlConfigWithTask(EchoTask);
-            var stringBuilder = new StringBuilder();
+            StringBuilder stringBuilder = new StringBuilder();
             Console.SetOut(new StringWriter(stringBuilder));
 
-            var sut = new EawXBuildApplication(_services.BuildServiceProvider(), options);
+            EawXBuildApplication sut = new EawXBuildApplication(_services.BuildServiceProvider(), options);
 
             sut.Run();
 
-            var actual = stringBuilder.ToString().Trim();
+            string actual = stringBuilder.ToString().Trim();
             Assert.AreEqual("Hello World", actual);
         }
 
-        private static ServiceCollection ConfigureServices(LogLevel logLevel = LogLevel.None) {
-            var services = new ServiceCollection();
+        private static ServiceCollection ConfigureServices(LogLevel logLevel = LogLevel.None)
+        {
+            ServiceCollection services = new ServiceCollection();
             services.AddLogging(builder => builder.AddConsole());
             services.Configure<LoggerFilterOptions>(options =>
                 options.AddFilter<ConsoleLoggerProvider>(null, logLevel));

--- a/eawx-build-test/Native/FileLinkerSpy.cs
+++ b/eawx-build-test/Native/FileLinkerSpy.cs
@@ -1,17 +1,16 @@
 using EawXBuild.Native;
 
-namespace EawXBuildTest.Native {
-    public class FileLinkerSpy : IFileLinker {
-        private bool _createLinkWasCalled;
+namespace EawXBuildTest.Native
+{
+    public class FileLinkerSpy : IFileLinker
+    {
         public string ReceivedSource { get; private set; }
         public string ReceivedTarget { get; private set; }
 
-        public bool CreateLinkWasCalled {
-            get => _createLinkWasCalled;
-            private set => _createLinkWasCalled = value;
-        }
+        public bool CreateLinkWasCalled { get; private set; }
 
-        public void CreateLink(string source, string target) {
+        public void CreateLink(string source, string target)
+        {
             CreateLinkWasCalled = true;
             ReceivedSource = source;
             ReceivedTarget = target;

--- a/eawx-build-test/Native/FileLinkerTest.cs
+++ b/eawx-build-test/Native/FileLinkerTest.cs
@@ -1,32 +1,36 @@
+using System.IO;
 using System.IO.Abstractions;
 using EawXBuild.Native;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Native {
+namespace EawXBuildTest.Native
+{
     [TestClass]
-    public class FileLinkerTest {
-        private readonly IFileSystem _fileSystem = new FileSystem();
-        private IDirectoryInfo _directoryInfo;
-        private IFileInfo _sourceFileInfo;
-        private IFileInfo _targetFileInfo;
-
+    public class FileLinkerTest
+    {
         private const string FolderPath = "folder";
         private const string UnixFilePath = FolderPath + "/testFile.txt";
         private const string UnixLinkedFilePath = FolderPath + "/linkedFile.txt";
         private const string WinFilePath = FolderPath + @"\testFile.txt";
         private const string WinLinkedFilePath = FolderPath + @"\linkedFile.txt";
+        private readonly IFileSystem _fileSystem = new FileSystem();
+        private IDirectoryInfo _directoryInfo;
+        private IFileInfo _sourceFileInfo;
+        private IFileInfo _targetFileInfo;
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             _directoryInfo = _fileSystem.DirectoryInfo.FromDirectoryName(FolderPath);
             _directoryInfo.Create();
             _sourceFileInfo = _fileSystem.FileInfo.FromFileName(GetPlatformSourcePath());
             _targetFileInfo = _fileSystem.FileInfo.FromFileName(GetPlatformTargetPath());
-            using var stream = _sourceFileInfo.Create();
+            using Stream stream = _sourceFileInfo.Create();
         }
 
         [TestCleanup]
-        public void TearDown() {
+        public void TearDown()
+        {
             _sourceFileInfo.Delete();
             _targetFileInfo.Delete();
             _directoryInfo.Delete();
@@ -35,8 +39,9 @@ namespace EawXBuildTest.Native {
         }
 
         [PlatformSpecificTestMethod("OSX")]
-        public void GivenRunningMacOS__WhenLinkingFileWithUnixStylePath__FileShouldExist() {
-            var sut = new MacOSFileLinker();
+        public void GivenRunningMacOS__WhenLinkingFileWithUnixStylePath__FileShouldExist()
+        {
+            MacOSFileLinker sut = new MacOSFileLinker();
 
             sut.CreateLink(UnixFilePath, UnixLinkedFilePath);
 
@@ -44,8 +49,9 @@ namespace EawXBuildTest.Native {
         }
 
         [PlatformSpecificTestMethod("OSX")]
-        public void GivenRunningMacOS__WhenLinkingFileWithWinStylePath__FileShouldExist() {
-            var sut = new MacOSFileLinker();
+        public void GivenRunningMacOS__WhenLinkingFileWithWinStylePath__FileShouldExist()
+        {
+            MacOSFileLinker sut = new MacOSFileLinker();
 
             sut.CreateLink(WinFilePath, WinLinkedFilePath);
 
@@ -53,8 +59,9 @@ namespace EawXBuildTest.Native {
         }
 
         [PlatformSpecificTestMethod("Windows")]
-        public void GivenRunningWindows__WhenLinkingFileWithUnixStylePath__FileShouldExist() {
-            var sut = new WinFileLinker();
+        public void GivenRunningWindows__WhenLinkingFileWithUnixStylePath__FileShouldExist()
+        {
+            WinFileLinker sut = new WinFileLinker();
 
             sut.CreateLink(UnixFilePath, UnixLinkedFilePath);
 
@@ -62,8 +69,9 @@ namespace EawXBuildTest.Native {
         }
 
         [PlatformSpecificTestMethod("Windows")]
-        public void GivenRunningWindows__WhenLinkingFileWithWinStylePath__FileShouldExist() {
-            var sut = new WinFileLinker();
+        public void GivenRunningWindows__WhenLinkingFileWithWinStylePath__FileShouldExist()
+        {
+            WinFileLinker sut = new WinFileLinker();
 
             sut.CreateLink(WinFilePath, WinLinkedFilePath);
 
@@ -71,8 +79,9 @@ namespace EawXBuildTest.Native {
         }
 
         [PlatformSpecificTestMethod("Linux")]
-        public void GivenRunningLinux__WhenLinkingFileWithUnixStylePath__FileShouldExist() {
-            var sut = new LinuxFileLinker();
+        public void GivenRunningLinux__WhenLinkingFileWithUnixStylePath__FileShouldExist()
+        {
+            LinuxFileLinker sut = new LinuxFileLinker();
 
             sut.CreateLink(UnixFilePath, UnixLinkedFilePath);
 
@@ -80,19 +89,22 @@ namespace EawXBuildTest.Native {
         }
 
         [PlatformSpecificTestMethod("Linux")]
-        public void GivenRunningLinux__WhenLinkingFileWithWinStylePath__FileShouldExist() {
-            var sut = new LinuxFileLinker();
+        public void GivenRunningLinux__WhenLinkingFileWithWinStylePath__FileShouldExist()
+        {
+            LinuxFileLinker sut = new LinuxFileLinker();
 
             sut.CreateLink(WinFilePath, WinLinkedFilePath);
 
             Assert.IsTrue(_fileSystem.File.Exists(UnixLinkedFilePath));
         }
 
-        private static string GetPlatformSourcePath() {
+        private static string GetPlatformSourcePath()
+        {
             return TestUtility.IsWindows() ? WinFilePath : UnixFilePath;
         }
 
-        private static string GetPlatformTargetPath() {
+        private static string GetPlatformTargetPath()
+        {
             return TestUtility.IsWindows() ? WinLinkedFilePath : UnixLinkedFilePath;
         }
     }

--- a/eawx-build-test/Services/IO/IOServiceTest.cs
+++ b/eawx-build-test/Services/IO/IOServiceTest.cs
@@ -26,7 +26,7 @@ namespace EawXBuildTest.Services.IO {
         public void GivenAbsolutePathToFile__WithRootedPath__IsValidPath__IsExpected__WIN(string absoluteDirectoryPath,
             string fileExtension, bool expected) {
             const string fileName = "test";
-            var svc = new IOService(_fileSystem);
+            var svc = new IOHelperService(_fileSystem);
             Assert.AreEqual(expected, svc.IsValidPath(
                 _fileSystem.Path.Combine(absoluteDirectoryPath, fileName + fileExtension),
                 string.Empty, fileExtension));
@@ -43,7 +43,7 @@ namespace EawXBuildTest.Services.IO {
         public void GivenAbsolutePathToFile__WithRootedPath__IsValidPath__IsExpected__UNX(string absoluteDirectoryPath,
             string fileExtension, bool expected) {
             const string fileName = "test";
-            var svc = new IOService(_fileSystem);
+            var svc = new IOHelperService(_fileSystem);
             Assert.AreEqual(expected, svc.IsValidPath(
                 _fileSystem.Path.Combine(absoluteDirectoryPath, fileName + fileExtension),
                 string.Empty, fileExtension));
@@ -60,7 +60,7 @@ namespace EawXBuildTest.Services.IO {
         public void GivenRelativePathToFile__WithoutRootedPath__IsValidPath__IsFalse_WIN(string absoluteDirectoryPath,
             string fileExtension) {
             const string fileName = "test";
-            var svc = new IOService(_fileSystem);
+            var svc = new IOHelperService(_fileSystem);
             Assert.IsFalse(svc.IsValidPath(
                 _fileSystem.Path.Combine(absoluteDirectoryPath, fileName + fileExtension),
                 string.Empty, fileExtension));
@@ -76,7 +76,7 @@ namespace EawXBuildTest.Services.IO {
         [DataRow("data/path", ".dat")]
         public void GivenRelativePathToFile__WithoutRootedPath__IsValidPath__IsFalse_UNX(string absoluteDirectoryPath,
             string fileExtension) {
-            var svc = new IOService(_fileSystem);
+            var svc = new IOHelperService(_fileSystem);
 
             const string fileName = "test";
             Assert.IsFalse(svc.IsValidPath(
@@ -93,7 +93,7 @@ namespace EawXBuildTest.Services.IO {
         public void GivenRelativePathToFile__IsValidPath__IsExpected_UNX(string relativeDirectoryPath, string basePath,
             string fileExtension, bool expected) {
             const string fileName = "test";
-            var svc = new IOService(_fileSystem);
+            var svc = new IOHelperService(_fileSystem);
             Assert.AreEqual(expected, svc.IsValidPath(
                 _fileSystem.Path.Combine(relativeDirectoryPath, fileName + fileExtension),
                 basePath, fileExtension));
@@ -108,7 +108,7 @@ namespace EawXBuildTest.Services.IO {
         public void GivenRelativePathToFile__IsValidPath__IsExpected_WIN(string relativeDirectoryPath, string basePath,
             string fileExtension, bool expected) {
             const string fileName = "test";
-            var svc = new IOService(_fileSystem);
+            var svc = new IOHelperService(_fileSystem);
             Assert.AreEqual(expected, svc.IsValidPath(
                 _fileSystem.Path.Combine(relativeDirectoryPath, fileName + fileExtension),
                 basePath, fileExtension));

--- a/eawx-build-test/Services/IO/IOServiceTest.cs
+++ b/eawx-build-test/Services/IO/IOServiceTest.cs
@@ -3,15 +3,18 @@ using EawXBuild.Services.IO;
 using EawXBuildTest.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Services.IO {
+namespace EawXBuildTest.Services.IO
+{
     [TestClass]
-    public class IOServiceTest {
-        private MockFileSystem _fileSystem;
+    public class IOServiceTest
+    {
         private FileSystemAssertions _assertions;
+        private MockFileSystem _fileSystem;
 
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             TestUtility.GetConfiguredMockFileSystem(out _fileSystem, out _assertions);
         }
 
@@ -24,9 +27,10 @@ namespace EawXBuildTest.Services.IO {
         [DataRow("C:/da/path", ".xml", false)]
         [DataRow("C:/data/path", ".dat", false)]
         public void GivenAbsolutePathToFile__WithRootedPath__IsValidPath__IsExpected__WIN(string absoluteDirectoryPath,
-            string fileExtension, bool expected) {
+            string fileExtension, bool expected)
+        {
             const string fileName = "test";
-            var svc = new IOHelperService(_fileSystem);
+            IOHelperService svc = new IOHelperService(_fileSystem);
             Assert.AreEqual(expected, svc.IsValidPath(
                 _fileSystem.Path.Combine(absoluteDirectoryPath, fileName + fileExtension),
                 string.Empty, fileExtension));
@@ -41,9 +45,10 @@ namespace EawXBuildTest.Services.IO {
         [DataRow("/mnt/c/da/path", ".xml", false)]
         [DataRow("/mnt/c/data/path", ".dat", false)]
         public void GivenAbsolutePathToFile__WithRootedPath__IsValidPath__IsExpected__UNX(string absoluteDirectoryPath,
-            string fileExtension, bool expected) {
+            string fileExtension, bool expected)
+        {
             const string fileName = "test";
-            var svc = new IOHelperService(_fileSystem);
+            IOHelperService svc = new IOHelperService(_fileSystem);
             Assert.AreEqual(expected, svc.IsValidPath(
                 _fileSystem.Path.Combine(absoluteDirectoryPath, fileName + fileExtension),
                 string.Empty, fileExtension));
@@ -58,9 +63,10 @@ namespace EawXBuildTest.Services.IO {
         [DataRow("da/path", ".xml")]
         [DataRow("data/path", ".dat")]
         public void GivenRelativePathToFile__WithoutRootedPath__IsValidPath__IsFalse_WIN(string absoluteDirectoryPath,
-            string fileExtension) {
+            string fileExtension)
+        {
             const string fileName = "test";
-            var svc = new IOHelperService(_fileSystem);
+            IOHelperService svc = new IOHelperService(_fileSystem);
             Assert.IsFalse(svc.IsValidPath(
                 _fileSystem.Path.Combine(absoluteDirectoryPath, fileName + fileExtension),
                 string.Empty, fileExtension));
@@ -75,8 +81,9 @@ namespace EawXBuildTest.Services.IO {
         [DataRow("da/path", ".xml")]
         [DataRow("data/path", ".dat")]
         public void GivenRelativePathToFile__WithoutRootedPath__IsValidPath__IsFalse_UNX(string absoluteDirectoryPath,
-            string fileExtension) {
-            var svc = new IOHelperService(_fileSystem);
+            string fileExtension)
+        {
+            IOHelperService svc = new IOHelperService(_fileSystem);
 
             const string fileName = "test";
             Assert.IsFalse(svc.IsValidPath(
@@ -91,9 +98,10 @@ namespace EawXBuildTest.Services.IO {
         [DataRow("../../path", "/mnt/c/data/test/path", ".dat", false)]
         [DataRow("../path", "/mnt/c/data/test/path", ".xml", false)]
         public void GivenRelativePathToFile__IsValidPath__IsExpected_UNX(string relativeDirectoryPath, string basePath,
-            string fileExtension, bool expected) {
+            string fileExtension, bool expected)
+        {
             const string fileName = "test";
-            var svc = new IOHelperService(_fileSystem);
+            IOHelperService svc = new IOHelperService(_fileSystem);
             Assert.AreEqual(expected, svc.IsValidPath(
                 _fileSystem.Path.Combine(relativeDirectoryPath, fileName + fileExtension),
                 basePath, fileExtension));
@@ -106,9 +114,10 @@ namespace EawXBuildTest.Services.IO {
         [DataRow("../../path", "C:/data/test/path", ".dat", false)]
         [DataRow("../path", "C:/data/test/path", ".xml", false)]
         public void GivenRelativePathToFile__IsValidPath__IsExpected_WIN(string relativeDirectoryPath, string basePath,
-            string fileExtension, bool expected) {
+            string fileExtension, bool expected)
+        {
             const string fileName = "test";
-            var svc = new IOHelperService(_fileSystem);
+            IOHelperService svc = new IOHelperService(_fileSystem);
             Assert.AreEqual(expected, svc.IsValidPath(
                 _fileSystem.Path.Combine(relativeDirectoryPath, fileName + fileExtension),
                 basePath, fileExtension));

--- a/eawx-build-test/Services/Process/ProcessRunnerTest.cs
+++ b/eawx-build-test/Services/Process/ProcessRunnerTest.cs
@@ -5,45 +5,50 @@ using System.Text;
 using EawXBuild.Services.Process;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Services.Process {
+namespace EawXBuildTest.Services.Process
+{
     [TestClass]
-    public class ProcessRunnerTest {
-        
+    public class ProcessRunnerTest
+    {
         [PlatformSpecificTestMethod("Linux", "OSX")]
-        public void GivenEcho__WhenStarting__ShouldExitWithCodeZero() {
-            var sut = new ProcessRunner();
+        public void GivenEcho__WhenStarting__ShouldExitWithCodeZero()
+        {
+            ProcessRunner sut = new ProcessRunner();
 
             sut.Start("echo");
             sut.WaitForExit();
 
-            var actual = sut.ExitCode;
+            int actual = sut.ExitCode;
             Assert.AreEqual(0, actual);
         }
 
         [PlatformSpecificTestMethod("Linux", "OSX")]
-        public void GivenEchoWithArgs__WhenStarting__ShouldPrintOutArgs() {
-            var stringBuilder = new StringBuilder();
+        public void GivenEchoWithArgs__WhenStarting__ShouldPrintOutArgs()
+        {
+            StringBuilder stringBuilder = new StringBuilder();
             Console.SetOut(new StringWriter(stringBuilder));
 
-            var sut = new ProcessRunner();
+            ProcessRunner sut = new ProcessRunner();
 
             const string expected = "Hello World";
             sut.Start("echo", expected);
             sut.WaitForExit();
 
-            var actual = stringBuilder.ToString().Trim();
+            string actual = stringBuilder.ToString().Trim();
             Assert.AreEqual(expected, actual);
         }
 
         [PlatformSpecificTestMethod("Linux", "OSX")]
-        public void GivenProcessStartInfoForEcho__WhenStarting__ShouldPrintOutArgs() {
-            var stringBuilder = new StringBuilder();
+        public void GivenProcessStartInfoForEcho__WhenStarting__ShouldPrintOutArgs()
+        {
+            StringBuilder stringBuilder = new StringBuilder();
             Console.SetOut(new StringWriter(stringBuilder));
 
-            var sut = new ProcessRunner();
+            ProcessRunner sut = new ProcessRunner();
 
             const string expected = "Hello World";
-            var startInfo = new ProcessStartInfo {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
                 FileName = "echo",
                 Arguments = expected
             };
@@ -51,45 +56,49 @@ namespace EawXBuildTest.Services.Process {
             sut.Start(startInfo);
             sut.WaitForExit();
 
-            var actual = stringBuilder.ToString().Trim();
+            string actual = stringBuilder.ToString().Trim();
             Assert.AreEqual(expected, actual);
         }
-        
+
         [PlatformSpecificTestMethod("Windows")]
-        public void GivenCmdNoCommand__WhenStarting__ShouldExitWithCodeZero() {
-            var sut = new ProcessRunner();
+        public void GivenCmdNoCommand__WhenStarting__ShouldExitWithCodeZero()
+        {
+            ProcessRunner sut = new ProcessRunner();
 
             sut.Start("cmd.exe", "/c");
             sut.WaitForExit();
 
-            var actual = sut.ExitCode;
+            int actual = sut.ExitCode;
             Assert.AreEqual(0, actual);
         }
 
         [PlatformSpecificTestMethod("Windows")]
-        public void GivenCmdWithEchoCommandAndArgs__WhenStarting__ShouldPrintOutArgs() {
-            var stringBuilder = new StringBuilder();
+        public void GivenCmdWithEchoCommandAndArgs__WhenStarting__ShouldPrintOutArgs()
+        {
+            StringBuilder stringBuilder = new StringBuilder();
             Console.SetOut(new StringWriter(stringBuilder));
 
-            var sut = new ProcessRunner();
+            ProcessRunner sut = new ProcessRunner();
 
             const string expected = "Hello World";
             sut.Start("cmd.exe", "/c echo " + expected);
             sut.WaitForExit();
 
-            var actual = stringBuilder.ToString().Trim();
+            string actual = stringBuilder.ToString().Trim();
             Assert.AreEqual(expected, actual);
         }
 
         [PlatformSpecificTestMethod("Windows")]
-        public void GivenProcessStartInfoForCmdWithEcho__WhenStarting__ShouldPrintOutArgs() {
-            var stringBuilder = new StringBuilder();
+        public void GivenProcessStartInfoForCmdWithEcho__WhenStarting__ShouldPrintOutArgs()
+        {
+            StringBuilder stringBuilder = new StringBuilder();
             Console.SetOut(new StringWriter(stringBuilder));
 
-            var sut = new ProcessRunner();
+            ProcessRunner sut = new ProcessRunner();
 
             const string expected = "Hello World";
-            var startInfo = new ProcessStartInfo {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
                 FileName = "cmd.exe",
                 Arguments = "/c echo " + expected
             };
@@ -97,7 +106,7 @@ namespace EawXBuildTest.Services.Process {
             sut.Start(startInfo);
             sut.WaitForExit();
 
-            var actual = stringBuilder.ToString().Trim();
+            string actual = stringBuilder.ToString().Trim();
             Assert.AreEqual(expected, actual);
         }
     }

--- a/eawx-build-test/Services/Process/ProcessRunnerTestDoubles.cs
+++ b/eawx-build-test/Services/Process/ProcessRunnerTestDoubles.cs
@@ -2,24 +2,36 @@ using System.Diagnostics;
 using EawXBuild.Services.Process;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Services.Process {
-    public class ProcessRunnerDummy : IProcessRunner {
-        public virtual void Start(string executablePath) { }
+namespace EawXBuildTest.Services.Process
+{
+    public class ProcessRunnerDummy : IProcessRunner
+    {
+        public virtual void Start(string executablePath)
+        {
+        }
 
-        public virtual void Start(string executablePath, string arguments) { }
+        public virtual void Start(string executablePath, string arguments)
+        {
+        }
 
-        public virtual void Start(ProcessStartInfo startInfo) { }
+        public virtual void Start(ProcessStartInfo startInfo)
+        {
+        }
 
-        public virtual void WaitForExit() { }
+        public virtual void WaitForExit()
+        {
+        }
 
         public virtual int ExitCode { get; set; }
     }
 
-    public class ProcessRunnerStub : ProcessRunnerDummy {
+    public class ProcessRunnerStub : ProcessRunnerDummy
+    {
         public override int ExitCode { get; set; }
     }
 
-    public class ProcessRunnerSpy : ProcessRunnerDummy {
+    public class ProcessRunnerSpy : ProcessRunnerDummy
+    {
         public bool WasStarted { get; private set; }
 
         public string ExecutablePath { get; private set; }
@@ -27,46 +39,57 @@ namespace EawXBuildTest.Services.Process {
         public string Arguments { get; private set; }
         public string WorkingDirectory { get; private set; }
 
-        public override void Start(string executablePath) {
+        public override void Start(string executablePath)
+        {
             WasStarted = true;
             ExecutablePath = executablePath;
         }
 
-        public override void Start(string executablePath, string arguments) {
+        public override void Start(string executablePath, string arguments)
+        {
             Start(executablePath);
             Arguments = arguments;
         }
 
-        public override void Start(ProcessStartInfo startInfo) {
+        public override void Start(ProcessStartInfo startInfo)
+        {
             WorkingDirectory = startInfo.WorkingDirectory;
             Start(startInfo.FileName, startInfo.Arguments);
         }
 
-        public override void WaitForExit() { }
+        public override void WaitForExit()
+        {
+        }
     }
 
-    public class CallOrderVerifyingProcessRunnerMock : ProcessRunnerSpy {
+    public class CallOrderVerifyingProcessRunnerMock : ProcessRunnerSpy
+    {
         private string _callOrder = "";
 
-        public override void Start(string executablePath) {
-            _callOrder += "s";
-            base.Start(executablePath);
-        }
-
-        public override void WaitForExit() {
-            _callOrder += "w";
-            base.WaitForExit();
-        }
-
-        public override int ExitCode {
-            get {
+        public override int ExitCode
+        {
+            get
+            {
                 _callOrder += "e";
                 return 0;
             }
             set { }
         }
 
-        public void Verify() {
+        public override void Start(string executablePath)
+        {
+            _callOrder += "s";
+            base.Start(executablePath);
+        }
+
+        public override void WaitForExit()
+        {
+            _callOrder += "w";
+            base.WaitForExit();
+        }
+
+        public void Verify()
+        {
             const string expected = "swe";
             Assert.AreEqual(expected, _callOrder);
         }

--- a/eawx-build-test/Steam/Facepunch.Adapters/FacepunchSteamWorkshopAdapterTest.cs
+++ b/eawx-build-test/Steam/Facepunch.Adapters/FacepunchSteamWorkshopAdapterTest.cs
@@ -1,7 +1,5 @@
-using System;
 using System.IO;
 using System.IO.Abstractions;
-using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using EawXBuild.Steam;
 using EawXBuild.Steam.Facepunch.Adapters;
@@ -10,54 +8,62 @@ using Steamworks;
 using Steamworks.Ugc;
 using PublishResult = EawXBuild.Steam.PublishResult;
 
-namespace EawXBuildTest.Steam.Facepunch.Adapters {
+namespace EawXBuildTest.Steam.Facepunch.Adapters
+{
     [TestClass]
-    public class FacepunchSteamWorkshopAdapterTest {
+    public class FacepunchSteamWorkshopAdapterTest
+    {
         private const string SteamUploadPath = "my_steam_upload";
         private const string Title = "eaw-ci Test upload";
         private const string DescriptionFilePath = "description.txt";
         private const string Description = "The description";
         private const string Language = "Spanish";
-        private FileInfo _steamAppIdFile;
-        private IDirectoryInfo _itemFolder;
-        private FacepunchSteamWorkshopAdapter _sut;
         private FileSystem _fileSystem;
+        private IDirectoryInfo _itemFolder;
+        private FileInfo _steamAppIdFile;
+        private FacepunchSteamWorkshopAdapter _sut;
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             _fileSystem = new FileSystem();
             CreateItemFolderWithSingleFile(_fileSystem);
             CreateDescriptionFile(_fileSystem);
             _steamAppIdFile = new FileInfo("steam_appid.txt");
-            var streamWriter = _steamAppIdFile.AppendText();
+            StreamWriter streamWriter = _steamAppIdFile.AppendText();
             streamWriter.WriteLine("32470");
             streamWriter.Close();
 
             _sut = FacepunchSteamWorkshopAdapter.Instance;
         }
 
-        private static void CreateDescriptionFile(FileSystem fileSystem) {
-            var writer = fileSystem.File.CreateText(DescriptionFilePath);
+        private static void CreateDescriptionFile(FileSystem fileSystem)
+        {
+            StreamWriter writer = fileSystem.File.CreateText(DescriptionFilePath);
             writer.WriteLine(Description);
             writer.Close();
         }
 
-        private void CreateItemFolderWithSingleFile(FileSystem fileSystem) {
+        private void CreateItemFolderWithSingleFile(FileSystem fileSystem)
+        {
             _itemFolder = fileSystem.DirectoryInfo.FromDirectoryName(SteamUploadPath);
             _itemFolder.Create();
             fileSystem.File.CreateText(SteamUploadPath + "/file.txt").Close();
         }
 
         [TestCleanup]
-        public void TearDown() {
+        public void TearDown()
+        {
             SteamClient.Shutdown();
             _steamAppIdFile.Delete();
             _itemFolder.Delete(true);
         }
 
         [TestMethodWithRequiredEnvironmentVariable("EAW_CI_TEST_STEAM_CLIENT", "YES")]
-        public async Task GivenWorkshopChangeSet__WhenPublishingToSteam__ItemShouldBeOnWorkshop() {
-            var changeSet = new WorkshopItemChangeSet(_fileSystem) {
+        public async Task GivenWorkshopChangeSet__WhenPublishingToSteam__ItemShouldBeOnWorkshop()
+        {
+            WorkshopItemChangeSet changeSet = new WorkshopItemChangeSet(_fileSystem)
+            {
                 Title = Title,
                 DescriptionFilePath = DescriptionFilePath,
                 Language = Language,
@@ -66,25 +72,27 @@ namespace EawXBuildTest.Steam.Facepunch.Adapters {
             };
 
             _sut.Init(32470);
-            var publishTaskResult = await _sut.PublishNewWorkshopItemAsync(changeSet);
+            WorkshopItemPublishResult publishTaskResult = await _sut.PublishNewWorkshopItemAsync(changeSet);
 
-            var publishResult = publishTaskResult.Result;
+            PublishResult publishResult = publishTaskResult.Result;
             Assert.AreEqual(PublishResult.Ok, publishResult);
             await AssertItemMatchesSettings(publishTaskResult);
         }
 
         [TestMethodWithRequiredEnvironmentVariable("EAW_CI_TEST_STEAM_CLIENT", "YES")]
-        public async Task WhenQueryingForItemId__ShouldReturnItemWithId() {
+        public async Task WhenQueryingForItemId__ShouldReturnItemWithId()
+        {
             _sut.Init(32470);
             const ulong fotrWorkshopId = 1976399102;
-            var workshopItem = await _sut.QueryWorkshopItemByIdAsync(fotrWorkshopId);
+            IWorkshopItem? workshopItem = await _sut.QueryWorkshopItemByIdAsync(fotrWorkshopId);
 
             Assert.AreEqual(fotrWorkshopId, workshopItem.ItemId);
             StringAssert.StartsWith(workshopItem.Title, "Empire at War Expanded");
         }
 
-        private static async Task AssertItemMatchesSettings(WorkshopItemPublishResult publishTaskResult) {
-            var item = await Item.GetAsync(publishTaskResult.ItemId);
+        private static async Task AssertItemMatchesSettings(WorkshopItemPublishResult publishTaskResult)
+        {
+            Item? item = await Item.GetAsync(publishTaskResult.ItemId);
             Assert.IsTrue(item.HasValue);
 
             // TODO: The item data is not fetched properly even though it's there in Steam. Maybe it takes a while to register?

--- a/eawx-build-test/Steam/Facepunch.Adapters/Utilities.cs
+++ b/eawx-build-test/Steam/Facepunch.Adapters/Utilities.cs
@@ -1,11 +1,14 @@
 using System.IO;
 using System.IO.Abstractions;
 
-namespace EawXBuildTest.Steam.Facepunch.Adapters {
-    public class Utilities {
-        public static IFileInfo CreateSteamAppIdFile(IFileSystem fileSystem) {
-            var steamAppIdFile = fileSystem.FileInfo.FromFileName("steam_appid.txt");
-            var streamWriter = steamAppIdFile.AppendText();
+namespace EawXBuildTest.Steam.Facepunch.Adapters
+{
+    public class Utilities
+    {
+        public static IFileInfo CreateSteamAppIdFile(IFileSystem fileSystem)
+        {
+            IFileInfo steamAppIdFile = fileSystem.FileInfo.FromFileName("steam_appid.txt");
+            StreamWriter streamWriter = steamAppIdFile.AppendText();
             streamWriter.WriteLine("32470");
             streamWriter.Close();
 
@@ -13,19 +16,21 @@ namespace EawXBuildTest.Steam.Facepunch.Adapters {
         }
 
         public static IFileInfo CreateDescriptionFile(IFileSystem fileSystem, string descriptionFilePath,
-            string description) {
-            var writer = fileSystem.File.CreateText(descriptionFilePath);
+            string description)
+        {
+            StreamWriter writer = fileSystem.File.CreateText(descriptionFilePath);
             writer.Write(description);
             writer.Close();
-            var descriptionFile = fileSystem.FileInfo.FromFileName(descriptionFilePath);
+            IFileInfo descriptionFile = fileSystem.FileInfo.FromFileName(descriptionFilePath);
             return descriptionFile;
         }
 
-        public static IDirectoryInfo CreateItemFolderWithSingleFile(IFileSystem fileSystem, string steamUploadPath) {
-            var itemFolder = fileSystem.DirectoryInfo.FromDirectoryName(steamUploadPath);
+        public static IDirectoryInfo CreateItemFolderWithSingleFile(IFileSystem fileSystem, string steamUploadPath)
+        {
+            IDirectoryInfo itemFolder = fileSystem.DirectoryInfo.FromDirectoryName(steamUploadPath);
             itemFolder.Create();
             itemFolder.CreateSubdirectory("sub_dir");
-            using var streamWriter = fileSystem.File.CreateText(steamUploadPath + "/sub_dir/file.txt");
+            using StreamWriter streamWriter = fileSystem.File.CreateText(steamUploadPath + "/sub_dir/file.txt");
             streamWriter.Write("My awesome content!");
             streamWriter.Close();
 

--- a/eawx-build-test/Steam/SteamWorkshopTestDoubles.cs
+++ b/eawx-build-test/Steam/SteamWorkshopTestDoubles.cs
@@ -3,38 +3,50 @@ using System.Threading.Tasks;
 using EawXBuild.Steam;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Steam {
-    public class SteamWorkshopDummy : ISteamWorkshop {
-        public virtual void Init(uint appId) { }
+namespace EawXBuildTest.Steam
+{
+    public class SteamWorkshopDummy : ISteamWorkshop
+    {
+        public virtual void Init(uint appId)
+        {
+        }
 
-        public virtual void Shutdown() { }
+        public virtual void Shutdown()
+        {
+        }
 
         public virtual async Task<WorkshopItemPublishResult> PublishNewWorkshopItemAsync(
-            IWorkshopItemChangeSet settings) {
+            IWorkshopItemChangeSet settings)
+        {
             return null;
         }
 
-        public virtual async Task<IWorkshopItem> QueryWorkshopItemByIdAsync(ulong id) {
+        public virtual async Task<IWorkshopItem> QueryWorkshopItemByIdAsync(ulong id)
+        {
             return null;
         }
     }
 
-    public class SteamWorkshopStub : SteamWorkshopDummy {
+    public class SteamWorkshopStub : SteamWorkshopDummy
+    {
         public WorkshopItemPublishResult WorkshopItemPublishResult { get; set; }
 
         public Dictionary<ulong, IWorkshopItem> WorkshopItemsById { get; } = new Dictionary<ulong, IWorkshopItem>();
 
         public override async Task<WorkshopItemPublishResult> PublishNewWorkshopItemAsync(
-            IWorkshopItemChangeSet settings) {
+            IWorkshopItemChangeSet settings)
+        {
             return WorkshopItemPublishResult;
         }
 
-        public override Task<IWorkshopItem> QueryWorkshopItemByIdAsync(ulong id) {
+        public override Task<IWorkshopItem> QueryWorkshopItemByIdAsync(ulong id)
+        {
             return Task.FromResult(WorkshopItemsById[id]);
         }
     }
 
-    public class SteamWorkshopSpy : SteamWorkshopStub {
+    public class SteamWorkshopSpy : SteamWorkshopStub
+    {
         public uint AppId { get; private set; }
 
         public IWorkshopItemChangeSet ReceivedSettings { get; private set; }
@@ -45,50 +57,58 @@ namespace EawXBuildTest.Steam {
 
         public bool WasShutdown { get; private set; }
 
-        public override void Init(uint appId) {
+        public override void Init(uint appId)
+        {
             AppId = appId;
             CallOrder += "a";
             WasInitialized = true;
         }
 
-        public override void Shutdown() {
+        public override void Shutdown()
+        {
             CallOrder += "d";
             WasShutdown = true;
         }
 
-        public override Task<WorkshopItemPublishResult> PublishNewWorkshopItemAsync(IWorkshopItemChangeSet settings) {
+        public override Task<WorkshopItemPublishResult> PublishNewWorkshopItemAsync(IWorkshopItemChangeSet settings)
+        {
             ReceivedSettings = settings;
             CallOrder += "p";
 
             return Task.FromResult(WorkshopItemPublishResult);
         }
 
-        public override Task<IWorkshopItem> QueryWorkshopItemByIdAsync(ulong id) {
+        public override Task<IWorkshopItem> QueryWorkshopItemByIdAsync(ulong id)
+        {
             CallOrder += "q";
 
             return base.QueryWorkshopItemByIdAsync(id);
         }
     }
 
-    public class VerifyAwaitPublishTaskMock : SteamWorkshopSpy {
+    public class VerifyAwaitPublishTaskMock : SteamWorkshopSpy
+    {
         private string _eventOrder = "";
 
         public override async Task<WorkshopItemPublishResult> PublishNewWorkshopItemAsync(
-            IWorkshopItemChangeSet settings) {
-            var publishTask = base.PublishNewWorkshopItemAsync(settings);
+            IWorkshopItemChangeSet settings)
+        {
+            Task<WorkshopItemPublishResult> publishTask = base.PublishNewWorkshopItemAsync(settings);
             Task.WaitAll(publishTask);
-            var workshopItemPublishResult = publishTask.Result;
+            WorkshopItemPublishResult workshopItemPublishResult = publishTask.Result;
 
             await Task.Delay(500);
             _eventOrder += "p";
             return workshopItemPublishResult;
         }
 
-        public override void Shutdown() {
+        public override void Shutdown()
+        {
             _eventOrder += "d";
         }
 
-        public void Verify() {
+        public void Verify()
+        {
             Assert.AreEqual("pd", _eventOrder);
         }
     }

--- a/eawx-build-test/Steam/VerifySteamClientAndWorkshopItemCallOrderMock.cs
+++ b/eawx-build-test/Steam/VerifySteamClientAndWorkshopItemCallOrderMock.cs
@@ -2,40 +2,43 @@ using System.Threading.Tasks;
 using EawXBuild.Steam;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Steam {
-    public class VerifySteamClientAndWorkshopItemCallOrderMock : ISteamWorkshop, IWorkshopItem {
-        private string _eventOrder = "";
-
+namespace EawXBuildTest.Steam
+{
+    public class VerifySteamClientAndWorkshopItemCallOrderMock : ISteamWorkshop, IWorkshopItem
+    {
         private const string ErrorMessage =
             "Expected Init then await QueryWorkshopItemAsync, await UpdateItemAsync and finally Shutdown";
 
-        public void Verify() {
-            Assert.AreEqual("aqud", _eventOrder, ErrorMessage);
-        }
+        private string _eventOrder = "";
 
-        public Task<WorkshopItemPublishResult> PublishNewWorkshopItemAsync(IWorkshopItemChangeSet settings) {
+        public Task<WorkshopItemPublishResult> PublishNewWorkshopItemAsync(IWorkshopItemChangeSet settings)
+        {
             _eventOrder += "p";
             return Task.FromResult(new WorkshopItemPublishResult(0, PublishResult.Ok));
         }
 
-        public void Init(uint appId) {
+        public void Init(uint appId)
+        {
             _eventOrder += "a";
         }
 
-        public async Task<IWorkshopItem> QueryWorkshopItemByIdAsync(ulong id) {
+        public async Task<IWorkshopItem> QueryWorkshopItemByIdAsync(ulong id)
+        {
             await Task.Delay(100);
             _eventOrder += "q";
             return this;
         }
 
-        public async Task<PublishResult> UpdateItemAsync(IWorkshopItemChangeSet settings) {
+        public void Shutdown()
+        {
+            _eventOrder += "d";
+        }
+
+        public async Task<PublishResult> UpdateItemAsync(IWorkshopItemChangeSet settings)
+        {
             await Task.Delay(100);
             _eventOrder += "u";
             return PublishResult.Ok;
-        }
-
-        public void Shutdown() {
-            _eventOrder += "d";
         }
 
         public ulong ItemId => 0;
@@ -43,5 +46,10 @@ namespace EawXBuildTest.Steam {
         public string Title => string.Empty;
 
         public string Description => string.Empty;
+
+        public void Verify()
+        {
+            Assert.AreEqual("aqud", _eventOrder, ErrorMessage);
+        }
     }
 }

--- a/eawx-build-test/Steam/WorkshopItemChangeSetTest.cs
+++ b/eawx-build-test/Steam/WorkshopItemChangeSetTest.cs
@@ -5,22 +5,26 @@ using EawXBuild.Exceptions;
 using EawXBuild.Steam;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Steam {
+namespace EawXBuildTest.Steam
+{
     [TestClass]
-    public class WorkshopItemChangeSetTest {
+    public class WorkshopItemChangeSetTest
+    {
         [TestMethod]
         public void
-            GivenWorkshopItemChangeSetWithValidMinimalSettings__WhenCallingIsValid__ShouldReturnTrueAndNoException() {
-            var fileSystem = new MockFileSystem();
+            GivenWorkshopItemChangeSetWithValidMinimalSettings__WhenCallingIsValid__ShouldReturnTrueAndNoException()
+        {
+            MockFileSystem fileSystem = new MockFileSystem();
             const string itemFolderPath = "path/to/item/folder";
             fileSystem.AddDirectory(itemFolderPath);
 
-            var sut = new WorkshopItemChangeSet(fileSystem) {
+            WorkshopItemChangeSet sut = new WorkshopItemChangeSet(fileSystem)
+            {
                 Title = "Title",
                 ItemFolderPath = itemFolderPath
             };
 
-            var (isValid, exception) = sut.IsValidChangeSet();
+            (bool isValid, Exception exception) = sut.IsValidChangeSet();
 
             Assert.IsTrue(isValid);
             Assert.IsNull(exception);
@@ -28,15 +32,17 @@ namespace EawXBuildTest.Steam {
 
         [TestMethod]
         public void
-            GivenWorkshopItemChangeSetWithoutTitle__WhenCallingIsValid__ShouldReturnFalseAndInvalidOperationException() {
-            var fileSystem = new MockFileSystem();
+            GivenWorkshopItemChangeSetWithoutTitle__WhenCallingIsValid__ShouldReturnFalseAndInvalidOperationException()
+        {
+            MockFileSystem fileSystem = new MockFileSystem();
             const string itemFolderPath = "path/to/item/folder";
             fileSystem.AddDirectory(itemFolderPath);
-            var sut = new WorkshopItemChangeSet(fileSystem) {
+            WorkshopItemChangeSet sut = new WorkshopItemChangeSet(fileSystem)
+            {
                 ItemFolderPath = itemFolderPath
             };
 
-            var (isValid, exception) = sut.IsValidChangeSet();
+            (bool isValid, Exception exception) = sut.IsValidChangeSet();
 
             Assert.IsFalse(isValid);
             Assert.IsInstanceOfType(exception, typeof(InvalidOperationException));
@@ -45,14 +51,16 @@ namespace EawXBuildTest.Steam {
 
         [TestMethod]
         public void
-            GivenWorkshopItemWithoutItemFolderPath__WhenCallingIsValid__ShouldReturnFalseAndInvalidOperationException() {
-            var fileSystem = new MockFileSystem();
+            GivenWorkshopItemWithoutItemFolderPath__WhenCallingIsValid__ShouldReturnFalseAndInvalidOperationException()
+        {
+            MockFileSystem fileSystem = new MockFileSystem();
 
-            var sut = new WorkshopItemChangeSet(fileSystem) {
-                Title = "Title",
+            WorkshopItemChangeSet sut = new WorkshopItemChangeSet(fileSystem)
+            {
+                Title = "Title"
             };
 
-            var (isValid, exception) = sut.IsValidChangeSet();
+            (bool isValid, Exception exception) = sut.IsValidChangeSet();
 
             Assert.IsFalse(isValid);
             Assert.IsInstanceOfType(exception, typeof(InvalidOperationException));
@@ -61,16 +69,18 @@ namespace EawXBuildTest.Steam {
 
         [TestMethod]
         public void
-            GivenWorkshopItemChangeSetWithNonExistingItemFolder__WhenCallingIsValid__ShouldReturnFalseAndDirectoryNotFoundException() {
-            var fileSystem = new MockFileSystem();
+            GivenWorkshopItemChangeSetWithNonExistingItemFolder__WhenCallingIsValid__ShouldReturnFalseAndDirectoryNotFoundException()
+        {
+            MockFileSystem fileSystem = new MockFileSystem();
 
             const string nonExistingFolder = "non/existing/folder";
-            var sut = new WorkshopItemChangeSet(fileSystem) {
+            WorkshopItemChangeSet sut = new WorkshopItemChangeSet(fileSystem)
+            {
                 Title = "Title",
                 ItemFolderPath = nonExistingFolder
             };
 
-            var (isValid, exception) = sut.IsValidChangeSet();
+            (bool isValid, Exception exception) = sut.IsValidChangeSet();
 
             Assert.IsFalse(isValid);
             Assert.IsInstanceOfType(exception, typeof(DirectoryNotFoundException));
@@ -78,17 +88,19 @@ namespace EawXBuildTest.Steam {
 
         [TestMethod]
         public void
-            GivenWorkshopItemChangeSetWithAbsoluteItemFolderPath__WhenCallingIsValid__ShouldReturnFalseAndNoRelativePathException() {
+            GivenWorkshopItemChangeSetWithAbsoluteItemFolderPath__WhenCallingIsValid__ShouldReturnFalseAndNoRelativePathException()
+        {
             const string absolutePath = "/absolute/path";
-            var fileSystem = new MockFileSystem();
+            MockFileSystem fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(absolutePath);
 
-            var sut = new WorkshopItemChangeSet(fileSystem) {
+            WorkshopItemChangeSet sut = new WorkshopItemChangeSet(fileSystem)
+            {
                 Title = "Title",
                 ItemFolderPath = absolutePath
             };
 
-            var (isValid, exception) = sut.IsValidChangeSet();
+            (bool isValid, Exception exception) = sut.IsValidChangeSet();
 
             Assert.IsFalse(isValid);
             Assert.IsInstanceOfType(exception, typeof(NoRelativePathException));
@@ -96,19 +108,21 @@ namespace EawXBuildTest.Steam {
 
         [TestMethod]
         public void
-            GivenWorkshopItemChangeSetWithNonExistingDescriptionFile__WhenCallingIsValid__ShouldReturnFalseAndFileNotFoundException() {
+            GivenWorkshopItemChangeSetWithNonExistingDescriptionFile__WhenCallingIsValid__ShouldReturnFalseAndFileNotFoundException()
+        {
             const string itemFolderPath = "path/to/item/folder";
             const string descriptionFilePath = "non/existing/file";
 
-            var fileSystem = new MockFileSystem();
+            MockFileSystem fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(itemFolderPath);
-            var sut = new WorkshopItemChangeSet(fileSystem) {
+            WorkshopItemChangeSet sut = new WorkshopItemChangeSet(fileSystem)
+            {
                 Title = "Title",
                 ItemFolderPath = itemFolderPath,
                 DescriptionFilePath = descriptionFilePath
             };
 
-            var (isValid, exception) = sut.IsValidChangeSet();
+            (bool isValid, Exception exception) = sut.IsValidChangeSet();
 
             Assert.IsFalse(isValid);
             Assert.IsInstanceOfType(exception, typeof(FileNotFoundException));
@@ -116,21 +130,23 @@ namespace EawXBuildTest.Steam {
 
         [TestMethod]
         public void
-            GivenWorkshopItemChangeSetWithAbsoluteDescriptionFilePath__WhenCallingIsValid__ShouldReturnFalseAndNoRelativePathException() {
+            GivenWorkshopItemChangeSetWithAbsoluteDescriptionFilePath__WhenCallingIsValid__ShouldReturnFalseAndNoRelativePathException()
+        {
             const string itemFolderPath = "path/to/item/folder";
             const string descriptionFilePath = "/absolute/path/to/file";
 
-            var fileSystem = new MockFileSystem();
+            MockFileSystem fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(itemFolderPath);
             fileSystem.AddFile(descriptionFilePath, MockFileData.NullObject);
 
-            var sut = new WorkshopItemChangeSet(fileSystem) {
+            WorkshopItemChangeSet sut = new WorkshopItemChangeSet(fileSystem)
+            {
                 Title = "Title",
                 ItemFolderPath = itemFolderPath,
                 DescriptionFilePath = descriptionFilePath
             };
 
-            var (isValid, exception) = sut.IsValidChangeSet();
+            (bool isValid, Exception exception) = sut.IsValidChangeSet();
 
             Assert.IsFalse(isValid);
             Assert.IsInstanceOfType(exception, typeof(NoRelativePathException));
@@ -138,27 +154,30 @@ namespace EawXBuildTest.Steam {
 
         [TestMethod]
         public void
-            GivenWorkshopItemChangeSetWithDescriptionFilePath__WhenCallingGetDescriptionTextFromFile__ShouldReturnDescriptionText() {
+            GivenWorkshopItemChangeSetWithDescriptionFilePath__WhenCallingGetDescriptionTextFromFile__ShouldReturnDescriptionText()
+        {
             const string expectedDescriptionText = "The description";
-            var fileSystem = new MockFileSystem();
+            MockFileSystem fileSystem = new MockFileSystem();
             fileSystem.AddFile("path/to/description", new MockFileData(expectedDescriptionText));
-            var sut = new WorkshopItemChangeSet(fileSystem) {
+            WorkshopItemChangeSet sut = new WorkshopItemChangeSet(fileSystem)
+            {
                 DescriptionFilePath = "path/to/description"
             };
 
-            var actual = sut.GetDescriptionTextFromFile();
+            string actual = sut.GetDescriptionTextFromFile();
 
             Assert.AreEqual(expectedDescriptionText, actual);
         }
 
         [TestMethod]
         public void
-            GivenWorkshopItemChangeSetWithoutDescriptionFilePath__WhenCallingGetDescriptionTextFromFile__ShouldReturnEmptyString() {
-            var expectedDescriptionText = string.Empty;
-            var fileSystem = new MockFileSystem();
-            var sut = new WorkshopItemChangeSet(fileSystem);
+            GivenWorkshopItemChangeSetWithoutDescriptionFilePath__WhenCallingGetDescriptionTextFromFile__ShouldReturnEmptyString()
+        {
+            string expectedDescriptionText = string.Empty;
+            MockFileSystem fileSystem = new MockFileSystem();
+            WorkshopItemChangeSet sut = new WorkshopItemChangeSet(fileSystem);
 
-            var actual = sut.GetDescriptionTextFromFile();
+            string actual = sut.GetDescriptionTextFromFile();
 
             Assert.AreEqual(expectedDescriptionText, actual);
         }

--- a/eawx-build-test/Steam/WorkshopItemChangeSetTestDoubles.cs
+++ b/eawx-build-test/Steam/WorkshopItemChangeSetTestDoubles.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections.Generic;
 using EawXBuild.Steam;
 
-namespace EawXBuildTest.Steam {
-    public class WorkshopItemChangeSetDummy : IWorkshopItemChangeSet {
+namespace EawXBuildTest.Steam
+{
+    public class WorkshopItemChangeSetDummy : IWorkshopItemChangeSet
+    {
         public string Language { get; set; }
         public string Title { get; set; }
         public string ItemFolderPath { get; set; }
@@ -12,19 +14,23 @@ namespace EawXBuildTest.Steam {
 
         public HashSet<string> Tags { get; set; }
 
-        public virtual (bool, Exception) IsValidChangeSet() {
+        public virtual (bool, Exception) IsValidChangeSet()
+        {
             return (false, null);
         }
 
-        public string GetDescriptionTextFromFile() {
+        public string GetDescriptionTextFromFile()
+        {
             return string.Empty;
         }
     }
 
-    public class WorkshopItemChangeSetStub : WorkshopItemChangeSetDummy {
+    public class WorkshopItemChangeSetStub : WorkshopItemChangeSetDummy
+    {
         public (bool, Exception) ChangeSetValidationResult { get; set; }
 
-        public override (bool, Exception) IsValidChangeSet() {
+        public override (bool, Exception) IsValidChangeSet()
+        {
             return ChangeSetValidationResult;
         }
     }

--- a/eawx-build-test/Steam/WorkshopItemStub.cs
+++ b/eawx-build-test/Steam/WorkshopItemStub.cs
@@ -1,23 +1,28 @@
 using System.Threading.Tasks;
 using EawXBuild.Steam;
 
-namespace EawXBuildTest.Steam {
-    public class WorkshopItemStub : IWorkshopItem {
+namespace EawXBuildTest.Steam
+{
+    public class WorkshopItemStub : IWorkshopItem
+    {
         public PublishResult Result { get; set; } = PublishResult.Ok;
         public ulong ItemId { get; set; }
         public string Title { get; set; }
 
         public string Description { get; set; }
 
-        public virtual async Task<PublishResult> UpdateItemAsync(IWorkshopItemChangeSet settings) {
+        public virtual async Task<PublishResult> UpdateItemAsync(IWorkshopItemChangeSet settings)
+        {
             return Result;
         }
     }
 
-    public class WorkshopItemSpy : WorkshopItemStub {
+    public class WorkshopItemSpy : WorkshopItemStub
+    {
         public IWorkshopItemChangeSet ReceivedSettings { get; private set; }
 
-        public override Task<PublishResult> UpdateItemAsync(IWorkshopItemChangeSet settings) {
+        public override Task<PublishResult> UpdateItemAsync(IWorkshopItemChangeSet settings)
+        {
             ReceivedSettings = settings;
             return base.UpdateItemAsync(settings);
         }

--- a/eawx-build-test/Tasks/CleanTaskTest.cs
+++ b/eawx-build-test/Tasks/CleanTaskTest.cs
@@ -3,15 +3,18 @@ using EawXBuild.Exceptions;
 using EawXBuild.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Tasks {
+namespace EawXBuildTest.Tasks
+{
     [TestClass]
-    public class CleanTaskTest {
-        private MockFileSystem _fileSystem;
+    public class CleanTaskTest
+    {
         private FileSystemAssertions _assertions;
+        private MockFileSystem _fileSystem;
         private CleanTask _sut;
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             _fileSystem = new MockFileSystem();
             _assertions = new FileSystemAssertions(_fileSystem);
             _sut = new CleanTask(_fileSystem);
@@ -19,7 +22,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenPathToFile__WhenCallingRun__ShouldDeleteFile() {
+        public void GivenPathToFile__WhenCallingRun__ShouldDeleteFile()
+        {
             const string dirPath = "Data";
             const string filePath = "Data/MyFile.txt";
 
@@ -35,10 +39,11 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenPathToDirectory__WhenCallingRun__ShouldDeleteDirectory() {
+        public void GivenPathToDirectory__WhenCallingRun__ShouldDeleteDirectory()
+        {
             const string dirPath = "Data";
 
-            var fileSystem = new MockFileSystem();
+            MockFileSystem fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(dirPath);
 
             _sut.Path = dirPath;
@@ -50,7 +55,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenPathToDirectoryWithFiles__WhenCallingRun__ShouldDeleteDirectory() {
+        public void GivenPathToDirectoryWithFiles__WhenCallingRun__ShouldDeleteDirectory()
+        {
             const string dirPath = "Data";
             const string filePath = "Data/MyFile.txt";
 
@@ -66,7 +72,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [ExpectedException(typeof(NoRelativePathException))]
-        public void GivenAbsolutePath__WhenCallingRun__ShouldThrowNoRelativePathException() {
+        public void GivenAbsolutePath__WhenCallingRun__ShouldThrowNoRelativePathException()
+        {
             _sut.Path = "/absolute/path";
 
             _sut.Run();

--- a/eawx-build-test/Tasks/CopyPolicyTestDoubles.cs
+++ b/eawx-build-test/Tasks/CopyPolicyTestDoubles.cs
@@ -1,21 +1,29 @@
 using System.IO.Abstractions;
 using EawXBuild.Tasks;
 
-namespace EawXBuildTest.Tasks {
-    public class CopyPolicyDummy : ICopyPolicy {
-        public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite) { }
+namespace EawXBuildTest.Tasks
+{
+    public class CopyPolicyDummy : ICopyPolicy
+    {
+        public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite)
+        {
+        }
     }
 
-    public class CopyPolicySpy : ICopyPolicy {
+    public class CopyPolicySpy : ICopyPolicy
+    {
         public bool CopyCalled { get; private set; }
 
-        public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite) {
+        public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite)
+        {
             CopyCalled = true;
         }
     }
 
-    public class CopyPolicyFake : ICopyPolicy {
-        public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite) {
+    public class CopyPolicyFake : ICopyPolicy
+    {
+        public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite)
+        {
             source.CopyTo(target.FullName, overwrite);
         }
     }

--- a/eawx-build-test/Tasks/CopyTaskTest.cs
+++ b/eawx-build-test/Tasks/CopyTaskTest.cs
@@ -1,27 +1,34 @@
 using System;
-using System.IO;
 using System.IO.Abstractions.TestingHelpers;
 using EawXBuild.Exceptions;
 using EawXBuild.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Tasks {
+namespace EawXBuildTest.Tasks
+{
     [TestClass]
-    public class CopyTaskTest {
-        private MockFileSystem _fileSystem;
+    public class CopyTaskTest
+    {
         private FileSystemAssertions _assertions;
-        private EawXBuild.Tasks.CopyTask _sut;
+        private MockFileSystem _fileSystem;
+        private CopyTask _sut;
+
+        private static DateTimeOffset NewerWriteTime => new DateTimeOffset(new DateTime(2020, 3, 27), TimeSpan.Zero);
+
+        private static DateTimeOffset OlderWriteTime => new DateTimeOffset(new DateTime(2020, 3, 26), TimeSpan.Zero);
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             _fileSystem = new MockFileSystem();
             _assertions = new FileSystemAssertions(_fileSystem);
-            _sut = new EawXBuild.Tasks.CopyTask(new CopyPolicyFake(), _fileSystem);
+            _sut = new CopyTask(new CopyPolicyFake(), _fileSystem);
         }
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenPathToFileAndCopyDestination__WhenCallingRun__ShouldCreateFileAtDestination() {
+        public void GivenPathToFileAndCopyDestination__WhenCallingRun__ShouldCreateFileAtDestination()
+        {
             AddFile("Data/MyFile.txt", string.Empty);
 
             const string destination = "Copy/MyFile.txt";
@@ -36,7 +43,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenPathToFileAndCopyDestination__WhenCallingRun__ShouldCopyFileToDestination() {
+        public void GivenPathToFileAndCopyDestination__WhenCallingRun__ShouldCopyFileToDestination()
+        {
             const string sourceFile = "Data/MyFile.txt";
             const string destFile = "Copy/MyFile.txt";
 
@@ -51,14 +59,16 @@ namespace EawXBuildTest.Tasks {
         }
 
         [TestMethod]
-        public void GivenPathToFileAndDestination__WhenCallingRun__ShouldCopyUsingCopyPolicy() {
-            var fileSystem = new MockFileSystemWithFileInfoCopySpy();
-            var copyPolicySpy = new CopyPolicySpy();
+        public void GivenPathToFileAndDestination__WhenCallingRun__ShouldCopyUsingCopyPolicy()
+        {
+            MockFileSystemWithFileInfoCopySpy fileSystem = new MockFileSystemWithFileInfoCopySpy();
+            CopyPolicySpy copyPolicySpy = new CopyPolicySpy();
             fileSystem.FileSystem.AddFile("Data/MyFile.txt", string.Empty);
 
             const string destination = "Copy/MyFile.txt";
 
-            _sut = new CopyTask(copyPolicySpy, fileSystem) {
+            _sut = new CopyTask(copyPolicySpy, fileSystem)
+            {
                 Source = "Data/MyFile.txt",
                 Destination = destination
             };
@@ -71,7 +81,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenPathToDirectory__WhenCallingRun__ShouldCreateDirectoryAtDestination() {
+        public void GivenPathToDirectory__WhenCallingRun__ShouldCreateDirectoryAtDestination()
+        {
             const string sourceDirectory = "Data/SourceXML";
             const string destDirectory = "Copy/XML";
 
@@ -87,7 +98,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenPathToDirectoryWithFile__WhenCallingRun__ShouldCreateDirectoryWithFileAtDestination() {
+        public void GivenPathToDirectoryWithFile__WhenCallingRun__ShouldCreateDirectoryWithFileAtDestination()
+        {
             const string sourceDirectory = "Data/SourceXML";
             const string sourceFileName = "Data/SourceXML/MyFile.xml";
 
@@ -108,7 +120,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenPathToDirectoryWithSubDirectory__WhenCallingRun__ShouldAlsoCopySubDirectory() {
+        public void GivenPathToDirectoryWithSubDirectory__WhenCallingRun__ShouldAlsoCopySubDirectory()
+        {
             const string sourceDirectory = "Data/SourceXML";
             const string sourceSubDirectory = "Data/SourceXML/SubDirectory";
 
@@ -128,7 +141,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenPathToDirectoryWithTwoSubDirectoryLevels__WhenCallingRun__ShouldCopyBothLevels() {
+        public void GivenPathToDirectoryWithTwoSubDirectoryLevels__WhenCallingRun__ShouldCopyBothLevels()
+        {
             _fileSystem.AddDirectory("Data/SourceXML");
             _fileSystem.AddDirectory("Data/SourceXML/SubDirectory");
             _fileSystem.AddDirectory("Data/SourceXML/SubDirectory/SubDirectory2");
@@ -143,7 +157,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenPathToDirectoryWithSubDirectoryWithFile__WhenCallingRun__ShouldCopySubDirectoryWithFile() {
+        public void GivenPathToDirectoryWithSubDirectoryWithFile__WhenCallingRun__ShouldCopySubDirectoryWithFile()
+        {
             _fileSystem.AddDirectory("Data/SourceXML");
             _fileSystem.AddDirectory("Data/SourceXML/SubDirectory");
 
@@ -162,7 +177,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenDirectoryWithSubDirectoryWithoutRecursive__WhenCallingRun__ShouldNotCopySubDirectory() {
+        public void GivenDirectoryWithSubDirectoryWithoutRecursive__WhenCallingRun__ShouldNotCopySubDirectory()
+        {
             const string sourceDirectory = "Data/SourceXML";
             const string sourceSubDirectory = "Data/SourceXML/SubDirectory";
 
@@ -182,14 +198,15 @@ namespace EawXBuildTest.Tasks {
         }
 
         [TestMethod]
-        public void GivenDestFileExistsButSourceWasModifiedAfter__WhenCallingRun__ShouldOverrideDestFile() {
+        public void GivenDestFileExistsButSourceWasModifiedAfter__WhenCallingRun__ShouldOverrideDestFile()
+        {
             const string sourceFile = "Data/MyFile.txt";
             const string destFile = "Copy/MyFile.txt";
 
-            var newerWriteTime = new DateTimeOffset(new DateTime(2020, 3, 27), TimeSpan.Zero);
+            DateTimeOffset newerWriteTime = new DateTimeOffset(new DateTime(2020, 3, 27), TimeSpan.Zero);
             AddFile(sourceFile, "New Content", newerWriteTime);
 
-            var olderWriteTime = new DateTimeOffset(new DateTime(2020, 3, 26), TimeSpan.Zero);
+            DateTimeOffset olderWriteTime = new DateTimeOffset(new DateTime(2020, 3, 26), TimeSpan.Zero);
             AddFile(destFile, "Old Content", olderWriteTime);
 
             _sut.Source = sourceFile;
@@ -202,16 +219,17 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenDestFileExistAndHasNewerWriteTimeThanSourceFile__WhenCallingRun__ShouldNotOverrideDestFile() {
+        public void GivenDestFileExistAndHasNewerWriteTimeThanSourceFile__WhenCallingRun__ShouldNotOverrideDestFile()
+        {
             const string sourceFile = "Data/MyFile.txt";
             const string destFile = "Copy/MyFile.txt";
 
             const string expectedContent = "New Content";
 
-            var olderWriteTime = new DateTimeOffset(new DateTime(2020, 3, 26), TimeSpan.Zero);
+            DateTimeOffset olderWriteTime = new DateTimeOffset(new DateTime(2020, 3, 26), TimeSpan.Zero);
             AddFile(sourceFile, "Old Content", olderWriteTime);
 
-            var newerWriteTime = new DateTimeOffset(new DateTime(2020, 3, 27), TimeSpan.Zero);
+            DateTimeOffset newerWriteTime = new DateTimeOffset(new DateTime(2020, 3, 27), TimeSpan.Zero);
             AddFile(destFile, expectedContent, newerWriteTime);
 
             _sut.Source = sourceFile;
@@ -225,7 +243,8 @@ namespace EawXBuildTest.Tasks {
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
         public void
-            GivenDestDirectoryWithExistingFileButSourceWasModifiedAfter__WhenCallingRun__ShouldOverrideFileInDestDirectory() {
+            GivenDestDirectoryWithExistingFileButSourceWasModifiedAfter__WhenCallingRun__ShouldOverrideFileInDestDirectory()
+        {
             const string sourceDir = "Data";
             const string sourceFile = "Data/Sub/MyFile.txt";
 
@@ -246,7 +265,8 @@ namespace EawXBuildTest.Tasks {
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
         public void
-            GivenDestDirectoryWithExistingFileAndNewerWriteTimeThanSourceFile__WhenCallingRun__ShouldNotOverrideDestFile() {
+            GivenDestDirectoryWithExistingFileAndNewerWriteTimeThanSourceFile__WhenCallingRun__ShouldNotOverrideDestFile()
+        {
             const string sourceDir = "Data";
             const string sourceFile = "Data/Sub/MyFile.txt";
 
@@ -268,7 +288,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         public void
-            GivenDestDirectoryAndNewerWriteTimeThanSourceFile_WithAlwaysOverwrite__WhenCallingRun__ShouldOverwriteDestFile() {
+            GivenDestDirectoryAndNewerWriteTimeThanSourceFile_WithAlwaysOverwrite__WhenCallingRun__ShouldOverwriteDestFile()
+        {
             const string sourceDir = "Data";
             const string sourceFile = "Data/Sub/MyFile.txt";
 
@@ -291,7 +312,8 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
-        public void GivenFilePattern__WhenCallingRun__ShouldOnlyCopyFilesMatchingPattern() {
+        public void GivenFilePattern__WhenCallingRun__ShouldOnlyCopyFilesMatchingPattern()
+        {
             const string sourceDir = "Data";
             const string firstFile = "Data/MyFile.txt";
             const string secondFile = "Data/MySecondFile.txt";
@@ -322,7 +344,8 @@ namespace EawXBuildTest.Tasks {
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
         [ExpectedException(typeof(NoRelativePathException))]
-        public void GivenAbsolutePathAsSourceDir__WhenCallingRun__ShouldThrowNoRelativePathException() {
+        public void GivenAbsolutePathAsSourceDir__WhenCallingRun__ShouldThrowNoRelativePathException()
+        {
             const string sourceDir = "/absolute/path";
             _sut.Source = sourceDir;
 
@@ -332,7 +355,8 @@ namespace EawXBuildTest.Tasks {
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
         [ExpectedException(typeof(NoRelativePathException))]
-        public void GivenAbsolutePathAsDestDir__WhenCallingRun__ShouldThrowNoRelativePathException() {
+        public void GivenAbsolutePathAsDestDir__WhenCallingRun__ShouldThrowNoRelativePathException()
+        {
             const string destDir = "/absolute/path";
             _sut.Destination = destDir;
 
@@ -342,26 +366,26 @@ namespace EawXBuildTest.Tasks {
         [TestMethod]
         [TestCategory(TestUtility.TEST_TYPE_UTILITY)]
         [ExpectedException(typeof(NoSuchFileSystemObjectException))]
-        public void GivenNonExistingSourcePath__WhenCallingRun__ShouldThrowNoSuchFileSystemObjectException() {
+        public void GivenNonExistingSourcePath__WhenCallingRun__ShouldThrowNoSuchFileSystemObjectException()
+        {
             _sut.Source = "NonExistingPath";
             _sut.Run();
         }
 
 
-        private MockFileData GetFile(string path) {
+        private MockFileData GetFile(string path)
+        {
             return _fileSystem.GetFile(path);
         }
 
-        private static DateTimeOffset NewerWriteTime => new DateTimeOffset(new DateTime(2020, 3, 27), TimeSpan.Zero);
-
-        private static DateTimeOffset OlderWriteTime => new DateTimeOffset(new DateTime(2020, 3, 26), TimeSpan.Zero);
-
-        private void AddFile(string path, string content) {
+        private void AddFile(string path, string content)
+        {
             AddFile(path, content, DateTimeOffset.MinValue);
         }
 
-        private void AddFile(string sourceFile, string content, DateTimeOffset lastWriteTime) {
-            var sourceFileData = new MockFileData(content);
+        private void AddFile(string sourceFile, string content, DateTimeOffset lastWriteTime)
+        {
+            MockFileData sourceFileData = new MockFileData(content);
             sourceFileData.LastWriteTime = lastWriteTime;
             _fileSystem.AddFile(sourceFile, sourceFileData);
         }

--- a/eawx-build-test/Tasks/FileSystemAssertions.cs
+++ b/eawx-build-test/Tasks/FileSystemAssertions.cs
@@ -1,37 +1,46 @@
 using System.IO.Abstractions.TestingHelpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Tasks {
-    public class FileSystemAssertions {
+namespace EawXBuildTest.Tasks
+{
+    public class FileSystemAssertions
+    {
         private readonly MockFileSystem _fileSystem;
 
-        public FileSystemAssertions(MockFileSystem fileSystem) {
+        public FileSystemAssertions(MockFileSystem fileSystem)
+        {
             _fileSystem = fileSystem;
         }
 
-        public void AssertDirectoryDoesNotExist(string directory) {
+        public void AssertDirectoryDoesNotExist(string directory)
+        {
             Assert.IsFalse(_fileSystem.Directory.Exists(directory),
                 $"Directory {directory} should not exist, but does.");
         }
 
-        public void AssertDirectoryExists(string directory) {
+        public void AssertDirectoryExists(string directory)
+        {
             Assert.IsTrue(_fileSystem.Directory.Exists(directory), $"Directory {directory} should exist, but doesn't.");
         }
 
-        public void AssertFileExists(string expected) {
+        public void AssertFileExists(string expected)
+        {
             Assert.IsTrue(_fileSystem.FileExists(expected), $"File {expected} should exist, but doesn't");
         }
 
-        public void AssertFileDoesNotExist(string filePath) {
+        public void AssertFileDoesNotExist(string filePath)
+        {
             Assert.IsFalse(_fileSystem.FileExists(filePath), $"File {filePath} should not exist, but does.");
         }
 
-        public void AssertFileContentEquals(string expectedContent, MockFileData actual) {
+        public void AssertFileContentEquals(string expectedContent, MockFileData actual)
+        {
             Assert.AreEqual(expectedContent, actual.TextContents,
                 $"Expected content of file to be '{expectedContent}', but was '{actual.TextContents}'");
         }
 
-        public void AssertFileContentsAreEqual(MockFileData expected, MockFileData actual) {
+        public void AssertFileContentsAreEqual(MockFileData expected, MockFileData actual)
+        {
             CollectionAssert.AreEqual(expected.Contents, actual.Contents);
         }
     }

--- a/eawx-build-test/Tasks/LinkCopyPolicyTest.cs
+++ b/eawx-build-test/Tasks/LinkCopyPolicyTest.cs
@@ -1,30 +1,35 @@
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using EawXBuild.Tasks;
 using EawXBuildTest.Native;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Tasks {
+namespace EawXBuildTest.Tasks
+{
     [TestClass]
-    public class LinkCopyPolicyTest {
+    public class LinkCopyPolicyTest
+    {
         private string _currentDir;
+        private MockFileSystem _fileSystem;
         private string _sourceFileName;
         private string _targetFileName;
-        private MockFileSystem _fileSystem;
 
         [TestInitialize]
-        public void SetUp() {
+        public void SetUp()
+        {
             SetPlatformSpecificPaths();
             SetUpFileSystem();
         }
 
         [TestMethod]
-        public void GivenSourceAndTargetFileInfo__WhenCopyTo__ShouldCallLinkerWithFullFileNames() {
-            var sourceFile = _fileSystem.FileInfo.FromFileName(_sourceFileName);
-            var targetFile = _fileSystem.FileInfo.FromFileName(_targetFileName);
+        public void GivenSourceAndTargetFileInfo__WhenCopyTo__ShouldCallLinkerWithFullFileNames()
+        {
+            IFileInfo sourceFile = _fileSystem.FileInfo.FromFileName(_sourceFileName);
+            IFileInfo targetFile = _fileSystem.FileInfo.FromFileName(_targetFileName);
 
-            var fileLinkerSpy = new FileLinkerSpy();
-            var sut = new LinkCopyPolicy(fileLinkerSpy);
+            FileLinkerSpy fileLinkerSpy = new FileLinkerSpy();
+            LinkCopyPolicy sut = new LinkCopyPolicy(fileLinkerSpy);
 
             sut.CopyTo(sourceFile, targetFile, true);
 
@@ -33,20 +38,23 @@ namespace EawXBuildTest.Tasks {
         }
 
         [TestMethod]
-        public void GivenTargetExistsAndOverwriteFalse__WhenCallingCopyTo__ShouldNotCallLinker() {
-            var sourceFile = _fileSystem.FileInfo.FromFileName(_sourceFileName);
-            var targetFile = _fileSystem.FileInfo.FromFileName(_targetFileName);
+        public void GivenTargetExistsAndOverwriteFalse__WhenCallingCopyTo__ShouldNotCallLinker()
+        {
+            IFileInfo sourceFile = _fileSystem.FileInfo.FromFileName(_sourceFileName);
+            IFileInfo targetFile = _fileSystem.FileInfo.FromFileName(_targetFileName);
 
-            var fileLinkerSpy = new FileLinkerSpy();
-            var sut = new LinkCopyPolicy(fileLinkerSpy);
+            FileLinkerSpy fileLinkerSpy = new FileLinkerSpy();
+            LinkCopyPolicy sut = new LinkCopyPolicy(fileLinkerSpy);
 
             sut.CopyTo(sourceFile, targetFile, false);
 
             Assert.IsFalse(fileLinkerSpy.CreateLinkWasCalled);
         }
 
-        private void SetPlatformSpecificPaths() {
-            if (TestUtility.IsWindows()) {
+        private void SetPlatformSpecificPaths()
+        {
+            if (TestUtility.IsWindows())
+            {
                 _currentDir = @"C:\folder";
                 _sourceFileName = @"C:\folder\sourceFile";
                 _targetFileName = @"C:\home\folder\targetFile";
@@ -58,8 +66,10 @@ namespace EawXBuildTest.Tasks {
             _targetFileName = "/home/folder/targetFile";
         }
 
-        private void SetUpFileSystem() {
-            var files = new Dictionary<string, MockFileData> {
+        private void SetUpFileSystem()
+        {
+            Dictionary<string, MockFileData> files = new Dictionary<string, MockFileData>
+            {
                 {_sourceFileName, string.Empty},
                 {_targetFileName, string.Empty}
             };

--- a/eawx-build-test/Tasks/MockFileSystemWithFileInfoCopySpy.cs
+++ b/eawx-build-test/Tasks/MockFileSystemWithFileInfoCopySpy.cs
@@ -5,11 +5,14 @@ using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Security.AccessControl;
 
-namespace EawXBuildTest.Tasks {
-    public class MockFileSystemWithFileInfoCopySpy : IFileSystem {
+namespace EawXBuildTest.Tasks
+{
+    public class MockFileSystemWithFileInfoCopySpy : IFileSystem
+    {
         private readonly CachedFileInfoCopySpyFactory _cachedFileInfoCopySpyFactory;
 
-        public MockFileSystemWithFileInfoCopySpy() {
+        public MockFileSystemWithFileInfoCopySpy()
+        {
             _cachedFileInfoCopySpyFactory = new CachedFileInfoCopySpyFactory(FileSystem);
         }
 
@@ -25,52 +28,62 @@ namespace EawXBuildTest.Tasks {
     }
 
 
-    public class CachedFileInfoCopySpyFactory : IFileInfoFactory {
+    public class CachedFileInfoCopySpyFactory : IFileInfoFactory
+    {
         private readonly MockFileSystem _fileSystem;
         private readonly Dictionary<string, IFileInfo> fileCache = new Dictionary<string, IFileInfo>();
 
-        public CachedFileInfoCopySpyFactory(MockFileSystem fileSystem) {
+        public CachedFileInfoCopySpyFactory(MockFileSystem fileSystem)
+        {
             _fileSystem = fileSystem;
         }
 
-        public IFileInfo FromFileName(string fileName) {
+        public IFileInfo FromFileName(string fileName)
+        {
             if (fileCache.ContainsKey(fileName)) return fileCache[fileName];
-            var file = new FileInfoCopySpy(_fileSystem, fileName);
+            FileInfoCopySpy file = new FileInfoCopySpy(_fileSystem, fileName);
             fileCache[fileName] = file;
             return file;
         }
     }
 
-    public class FileInfoCopySpy : IFileInfo {
+    public class FileInfoCopySpy : IFileInfo
+    {
         private readonly MockFileInfo _fileInfo;
 
-        public FileInfoCopySpy(IMockFileDataAccessor fileSystem, string path) {
+        public FileInfoCopySpy(IMockFileDataAccessor fileSystem, string path)
+        {
             _fileInfo = new MockFileInfo(fileSystem, path);
         }
 
-        public Boolean FileWasCopied { get; set; }
+        public bool FileWasCopied { get; set; }
 
-        public void Delete() {
+        public void Delete()
+        {
             _fileInfo.Delete();
         }
 
-        public void Refresh() {
+        public void Refresh()
+        {
             _fileInfo.Refresh();
         }
 
         public IFileSystem FileSystem => _fileInfo.FileSystem;
 
-        public FileAttributes Attributes {
+        public FileAttributes Attributes
+        {
             get => _fileInfo.Attributes;
             set => _fileInfo.Attributes = value;
         }
 
-        public DateTime CreationTime {
+        public DateTime CreationTime
+        {
             get => _fileInfo.CreationTime;
             set => _fileInfo.CreationTime = value;
         }
 
-        public DateTime CreationTimeUtc {
+        public DateTime CreationTimeUtc
+        {
             get => _fileInfo.CreationTimeUtc;
             set => _fileInfo.CreationTimeUtc = value;
         }
@@ -79,111 +92,135 @@ namespace EawXBuildTest.Tasks {
         public string Extension => _fileInfo.Extension;
         public string FullName => _fileInfo.FullName;
 
-        public DateTime LastAccessTime {
+        public DateTime LastAccessTime
+        {
             get => _fileInfo.LastAccessTime;
             set => _fileInfo.LastAccessTime = value;
         }
 
-        public DateTime LastAccessTimeUtc {
+        public DateTime LastAccessTimeUtc
+        {
             get => _fileInfo.LastAccessTimeUtc;
             set => _fileInfo.LastAccessTimeUtc = value;
         }
 
-        public DateTime LastWriteTime {
+        public DateTime LastWriteTime
+        {
             get => _fileInfo.LastWriteTime;
             set => _fileInfo.LastWriteTime = value;
         }
 
-        public DateTime LastWriteTimeUtc {
+        public DateTime LastWriteTimeUtc
+        {
             get => _fileInfo.LastWriteTimeUtc;
             set => _fileInfo.LastWriteTimeUtc = value;
         }
 
         public string Name => _fileInfo.Name;
 
-        public StreamWriter AppendText() {
+        public StreamWriter AppendText()
+        {
             return _fileInfo.AppendText();
         }
 
-        public IFileInfo CopyTo(string destFileName) {
+        public IFileInfo CopyTo(string destFileName)
+        {
             FileWasCopied = true;
             return _fileInfo.CopyTo(destFileName);
         }
 
-        public IFileInfo CopyTo(string destFileName, bool overwrite) {
+        public IFileInfo CopyTo(string destFileName, bool overwrite)
+        {
             FileWasCopied = true;
             return _fileInfo.CopyTo(destFileName, overwrite);
         }
 
-        public Stream Create() {
+        public Stream Create()
+        {
             return _fileInfo.Create();
         }
 
-        public StreamWriter CreateText() {
+        public StreamWriter CreateText()
+        {
             return _fileInfo.CreateText();
         }
 
-        public void Decrypt() {
+        public void Decrypt()
+        {
             _fileInfo.Decrypt();
         }
 
-        public void Encrypt() {
+        public void Encrypt()
+        {
             _fileInfo.Encrypt();
         }
 
-        public FileSecurity GetAccessControl() {
+        public FileSecurity GetAccessControl()
+        {
             return _fileInfo.GetAccessControl();
         }
 
-        public FileSecurity GetAccessControl(AccessControlSections includeSections) {
+        public FileSecurity GetAccessControl(AccessControlSections includeSections)
+        {
             return _fileInfo.GetAccessControl(includeSections);
         }
 
-        public void MoveTo(string destFileName) {
+        public void MoveTo(string destFileName)
+        {
             _fileInfo.MoveTo(destFileName);
         }
 
-        public Stream Open(FileMode mode) {
+        public Stream Open(FileMode mode)
+        {
             return _fileInfo.Open(mode);
         }
 
-        public Stream Open(FileMode mode, FileAccess access) {
+        public Stream Open(FileMode mode, FileAccess access)
+        {
             return _fileInfo.Open(mode, access);
         }
 
-        public Stream Open(FileMode mode, FileAccess access, FileShare share) {
+        public Stream Open(FileMode mode, FileAccess access, FileShare share)
+        {
             return _fileInfo.Open(mode, access, share);
         }
 
-        public Stream OpenRead() {
+        public Stream OpenRead()
+        {
             return _fileInfo.OpenRead();
         }
 
-        public StreamReader OpenText() {
+        public StreamReader OpenText()
+        {
             return _fileInfo.OpenText();
         }
 
-        public Stream OpenWrite() {
+        public Stream OpenWrite()
+        {
             return _fileInfo.OpenWrite();
         }
 
-        public IFileInfo Replace(string destinationFileName, string destinationBackupFileName) {
+        public IFileInfo Replace(string destinationFileName, string destinationBackupFileName)
+        {
             return _fileInfo.Replace(destinationFileName, destinationBackupFileName);
         }
 
         public IFileInfo Replace(string destinationFileName, string destinationBackupFileName,
-            bool ignoreMetadataErrors) {
+            bool ignoreMetadataErrors)
+        {
             return _fileInfo.Replace(destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
         }
 
-        public void SetAccessControl(FileSecurity fileSecurity) {
+        public void SetAccessControl(FileSecurity fileSecurity)
+        {
             _fileInfo.SetAccessControl(fileSecurity);
         }
 
         public IDirectoryInfo Directory => _fileInfo.Directory;
         public string DirectoryName => _fileInfo.DirectoryName;
 
-        public bool IsReadOnly {
+        public bool IsReadOnly
+        {
             get => _fileInfo.IsReadOnly;
             set => _fileInfo.IsReadOnly = value;
         }

--- a/eawx-build-test/Tasks/RunProcessTaskTest.cs
+++ b/eawx-build-test/Tasks/RunProcessTaskTest.cs
@@ -1,19 +1,23 @@
+using System;
 using System.IO.Abstractions.TestingHelpers;
 using EawXBuild.Exceptions;
 using EawXBuild.Tasks;
 using EawXBuildTest.Services.Process;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Tasks {
+namespace EawXBuildTest.Tasks
+{
     [TestClass]
-    public class RunProcessTaskTest {
-        private RunProcessTask _sut;
-        private ProcessRunnerSpy _runner;
-        private MockFileSystem _filesystem;
+    public class RunProcessTaskTest
+    {
         private string _executablePath;
+        private MockFileSystem _filesystem;
+        private ProcessRunnerSpy _runner;
+        private RunProcessTask _sut;
 
         [TestInitialize]
-        public void Setup() {
+        public void Setup()
+        {
             _runner = new ProcessRunnerSpy();
             _filesystem = new MockFileSystem();
             _filesystem.AddFile("myProgram.exe", new MockFileData(string.Empty));
@@ -22,7 +26,8 @@ namespace EawXBuildTest.Tasks {
         }
 
         [TestMethod]
-        public void GivenPathToExecutable__WhenCallingRun__ShouldStartProcess() {
+        public void GivenPathToExecutable__WhenCallingRun__ShouldStartProcess()
+        {
             _sut.Run();
 
             AssertProcessWasStartedWithExecutable(_runner, _executablePath);
@@ -30,7 +35,8 @@ namespace EawXBuildTest.Tasks {
 
 
         [TestMethod]
-        public void GivenExecutablePathAndArguments__WhenCallingRun__ShouldStartProcessWithArguments() {
+        public void GivenExecutablePathAndArguments__WhenCallingRun__ShouldStartProcessWithArguments()
+        {
             const string arguments = "--first --second --third";
             _sut.Arguments = arguments;
 
@@ -40,14 +46,16 @@ namespace EawXBuildTest.Tasks {
         }
 
         [TestMethod]
-        public void GivenNoWorkingDirectory__WhenCallingRun__ShouldStartProcessInCurrentWorkingDirectory() {
+        public void GivenNoWorkingDirectory__WhenCallingRun__ShouldStartProcessInCurrentWorkingDirectory()
+        {
             _sut.Run();
-            Assert.AreEqual(System.Environment.CurrentDirectory, _runner.WorkingDirectory);
+            Assert.AreEqual(Environment.CurrentDirectory, _runner.WorkingDirectory);
         }
 
         [TestMethod]
         public void
-            GivenPathToExecutable_Arguments_And_WorkingDirectory__WhenCallingRun__ShouldStartProcessWithGivenConfig() {
+            GivenPathToExecutable_Arguments_And_WorkingDirectory__WhenCallingRun__ShouldStartProcessWithGivenConfig()
+        {
             const string arguments = "--first --second --third";
             const string workingDir = "working/directory";
             _sut.Arguments = arguments;
@@ -62,20 +70,22 @@ namespace EawXBuildTest.Tasks {
 
         [TestMethod]
         [ExpectedException(typeof(ProcessFailedException))]
-        public void GivenExecutableThatExitsWithCodeOne__WhenCallingRun__ShouldThrowProcessFailedException() {
-            var runner = new ProcessRunnerStub {ExitCode = 1};
-            var sut = new RunProcessTask(runner, _filesystem) {ExecutablePath = _executablePath};
+        public void GivenExecutableThatExitsWithCodeOne__WhenCallingRun__ShouldThrowProcessFailedException()
+        {
+            ProcessRunnerStub runner = new ProcessRunnerStub {ExitCode = 1};
+            RunProcessTask sut = new RunProcessTask(runner, _filesystem) {ExecutablePath = _executablePath};
 
             sut.Run();
         }
 
         [TestMethod]
         public void
-            GivenPathToExecutable__WhenCallingRun__ShouldCallStartFirst_Then_BlockUntilFinished_Then_CheckExitCode() {
-            var runner = new CallOrderVerifyingProcessRunnerMock();
+            GivenPathToExecutable__WhenCallingRun__ShouldCallStartFirst_Then_BlockUntilFinished_Then_CheckExitCode()
+        {
+            CallOrderVerifyingProcessRunnerMock runner = new CallOrderVerifyingProcessRunnerMock();
 
             const string executablePath = "myProgram.exe";
-            var sut = new RunProcessTask(runner, _filesystem) {ExecutablePath = executablePath};
+            RunProcessTask sut = new RunProcessTask(runner, _filesystem) {ExecutablePath = executablePath};
 
             sut.Run();
 
@@ -83,29 +93,34 @@ namespace EawXBuildTest.Tasks {
         }
 
         [TestMethod]
-        public void GivenFailingProcessButAllowedToFail__WhenCallingRun__ShouldNotThrowProcessFailedException() {
-            var runner = new ProcessRunnerStub {ExitCode = 1};
-            var sut = new RunProcessTask(runner, _filesystem) {ExecutablePath = _executablePath, AllowedToFail = true};
+        public void GivenFailingProcessButAllowedToFail__WhenCallingRun__ShouldNotThrowProcessFailedException()
+        {
+            ProcessRunnerStub runner = new ProcessRunnerStub {ExitCode = 1};
+            RunProcessTask sut = new RunProcessTask(runner, _filesystem)
+                {ExecutablePath = _executablePath, AllowedToFail = true};
 
             sut.Run();
         }
 
         [TestMethod]
         [ExpectedException(typeof(NoRelativePathException))]
-        public void GivenAbsolutePath__WhenCallingRun__ShouldThrowNoRelativePathException() {
+        public void GivenAbsolutePath__WhenCallingRun__ShouldThrowNoRelativePathException()
+        {
             _sut.ExecutablePath = "/absolute/path";
 
             _sut.Run();
         }
 
         [TestMethod]
-        public void GivenAbsolutePath__WhenCallingRun__ShouldNotStartProcess() {
+        public void GivenAbsolutePath__WhenCallingRun__ShouldNotStartProcess()
+        {
             _sut.ExecutablePath = "/absolute/path";
             Assert.ThrowsException<NoRelativePathException>(() => _sut.Run());
             Assert.IsFalse(_runner.WasStarted);
         }
 
-        private static void AssertProcessWasStartedWithExecutable(ProcessRunnerSpy runner, string executablePath) {
+        private static void AssertProcessWasStartedWithExecutable(ProcessRunnerSpy runner, string executablePath)
+        {
             Assert.IsTrue(runner.WasStarted, "Should have called Start(), but didn't");
             Assert.AreEqual(executablePath, runner.ExecutablePath,
                 $"Should have called Start() with {executablePath}, but was {runner.ExecutablePath}");

--- a/eawx-build-test/Tasks/Steam/CreateSteamWorkshopItemTaskTest.cs
+++ b/eawx-build-test/Tasks/Steam/CreateSteamWorkshopItemTaskTest.cs
@@ -6,9 +6,11 @@ using EawXBuild.Tasks.Steam;
 using EawXBuildTest.Steam;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Tasks.Steam {
+namespace EawXBuildTest.Tasks.Steam
+{
     [TestClass]
-    public class CreateSteamWorkshopItemTaskTest {
+    public class CreateSteamWorkshopItemTaskTest
+    {
         private const string Title = "My Workshop Item";
         private const string DescriptionFilePath = "path/to/description";
         private const string Language = "Spanish";
@@ -17,8 +19,10 @@ namespace EawXBuildTest.Tasks.Steam {
         private readonly HashSet<string> ExpectedTags = new HashSet<string> {"EAW", "FOC"};
 
         private static CreateSteamWorkshopItemTask MakeSutWithWorkshopAndChangeSet(ISteamWorkshop workshop,
-            IWorkshopItemChangeSet changeSet) {
-            return new CreateSteamWorkshopItemTask(workshop) {
+            IWorkshopItemChangeSet changeSet)
+        {
+            return new CreateSteamWorkshopItemTask(workshop)
+            {
                 AppId = AppId,
                 ChangeSet = changeSet
             };
@@ -26,9 +30,11 @@ namespace EawXBuildTest.Tasks.Steam {
 
         [TestMethod]
         public void
-            GivenTaskWithAppId_Title_Description_Language_Folder_And_Visibility__WhenRunningTask__ShouldPublishWithSettings() {
-            var workshopSpy = MakeSteamWorkshopSpy();
-            var changeSetStub = new WorkshopItemChangeSetStub {
+            GivenTaskWithAppId_Title_Description_Language_Folder_And_Visibility__WhenRunningTask__ShouldPublishWithSettings()
+        {
+            SteamWorkshopSpy workshopSpy = MakeSteamWorkshopSpy();
+            WorkshopItemChangeSetStub changeSetStub = new WorkshopItemChangeSetStub
+            {
                 ChangeSetValidationResult = (true, null),
 
                 Title = Title,
@@ -39,11 +45,11 @@ namespace EawXBuildTest.Tasks.Steam {
                 Tags = ExpectedTags
             };
 
-            var sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, changeSetStub);
+            CreateSteamWorkshopItemTask sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, changeSetStub);
 
             sut.Run();
 
-            var actual = workshopSpy.ReceivedSettings;
+            IWorkshopItemChangeSet actual = workshopSpy.ReceivedSettings;
             Assert.AreEqual(AppId, workshopSpy.AppId);
             Assert.AreEqual(Title, actual.Title);
             Assert.AreEqual(DescriptionFilePath, actual.DescriptionFilePath);
@@ -55,21 +61,23 @@ namespace EawXBuildTest.Tasks.Steam {
 
         [TestMethod]
         public void
-            GivenConfiguredTaskWithoutLanguage_And_Visibility__WhenRunningTask__ShouldPublishWith_EmptyDescription_PrivateVisibility_And_EnglishLanguage() {
-            var workshopSpy = MakeSteamWorkshopSpy();
-            var sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, CreateValidChangeSet());
+            GivenConfiguredTaskWithoutLanguage_And_Visibility__WhenRunningTask__ShouldPublishWith_EmptyDescription_PrivateVisibility_And_EnglishLanguage()
+        {
+            SteamWorkshopSpy workshopSpy = MakeSteamWorkshopSpy();
+            CreateSteamWorkshopItemTask sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, CreateValidChangeSet());
 
             sut.Run();
 
-            var actual = workshopSpy.ReceivedSettings;
+            IWorkshopItemChangeSet actual = workshopSpy.ReceivedSettings;
             AssertPublishedWithDefaultSettings(actual);
         }
 
         [TestMethod]
         public void
-            GivenTaskWithAppId__WhenRunningTask__ShouldSetAppIdThenPublishThenShutdown() {
-            var workshopSpy = MakeSteamWorkshopSpy();
-            var sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, CreateValidChangeSet());
+            GivenTaskWithAppId__WhenRunningTask__ShouldSetAppIdThenPublishThenShutdown()
+        {
+            SteamWorkshopSpy workshopSpy = MakeSteamWorkshopSpy();
+            CreateSteamWorkshopItemTask sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, CreateValidChangeSet());
 
             sut.Run();
 
@@ -78,11 +86,13 @@ namespace EawXBuildTest.Tasks.Steam {
 
         [TestMethod]
         public void
-            GivenValidTask__WhenRunningTask__ShouldShutdownAfterPublishFinished() {
-            var workshopMock = new VerifyAwaitPublishTaskMock {
+            GivenValidTask__WhenRunningTask__ShouldShutdownAfterPublishFinished()
+        {
+            VerifyAwaitPublishTaskMock workshopMock = new VerifyAwaitPublishTaskMock
+            {
                 WorkshopItemPublishResult = new WorkshopItemPublishResult(1, PublishResult.Ok)
             };
-            var sut = MakeSutWithWorkshopAndChangeSet(workshopMock, CreateValidChangeSet());
+            CreateSteamWorkshopItemTask sut = MakeSutWithWorkshopAndChangeSet(workshopMock, CreateValidChangeSet());
 
             sut.Run();
 
@@ -90,9 +100,10 @@ namespace EawXBuildTest.Tasks.Steam {
         }
 
         [TestMethod]
-        public void GivenTaskWithInvalidNewChangeSet__WhenRunningTask__ShouldThrowExceptionFromChangeSet() {
-            var workshopSpy = MakeSteamWorkshopSpy();
-            var sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, CreateInvalidChangeSet());
+        public void GivenTaskWithInvalidNewChangeSet__WhenRunningTask__ShouldThrowExceptionFromChangeSet()
+        {
+            SteamWorkshopSpy workshopSpy = MakeSteamWorkshopSpy();
+            CreateSteamWorkshopItemTask sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, CreateInvalidChangeSet());
 
             Action actual = () => sut.Run();
 
@@ -100,9 +111,10 @@ namespace EawXBuildTest.Tasks.Steam {
         }
 
         [TestMethod]
-        public void GivenTaskWithInvalidNewChangeSet__WhenRunningTask__ShouldNotPublishToSteamWorkshop() {
-            var workshopSpy = MakeSteamWorkshopSpy();
-            var sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, CreateInvalidChangeSet());
+        public void GivenTaskWithInvalidNewChangeSet__WhenRunningTask__ShouldNotPublishToSteamWorkshop()
+        {
+            SteamWorkshopSpy workshopSpy = MakeSteamWorkshopSpy();
+            CreateSteamWorkshopItemTask sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, CreateInvalidChangeSet());
 
             Action actual = () => sut.Run();
             Assert.ThrowsException<InvalidOperationException>(actual);
@@ -112,24 +124,28 @@ namespace EawXBuildTest.Tasks.Steam {
 
         [TestMethod]
         [ExpectedException(typeof(ProcessFailedException))]
-        public void GivenValidTask__WhenRunningTask_ButPublishFails__ShouldThrowProcessFailedException() {
-            var workshopStub = new SteamWorkshopStub {
+        public void GivenValidTask__WhenRunningTask_ButPublishFails__ShouldThrowProcessFailedException()
+        {
+            SteamWorkshopStub workshopStub = new SteamWorkshopStub
+            {
                 WorkshopItemPublishResult = new WorkshopItemPublishResult(AppId, PublishResult.Failed)
             };
 
-            var sut = MakeSutWithWorkshopAndChangeSet(workshopStub, CreateValidChangeSet());
+            CreateSteamWorkshopItemTask sut = MakeSutWithWorkshopAndChangeSet(workshopStub, CreateValidChangeSet());
 
             sut.Run();
         }
 
         [TestMethod]
         public void
-            GivenValidTask__WhenRunningTask_ButPublishFails__ShouldShutdownSteamClient() {
-            var workshopSpy = new SteamWorkshopSpy {
+            GivenValidTask__WhenRunningTask_ButPublishFails__ShouldShutdownSteamClient()
+        {
+            SteamWorkshopSpy workshopSpy = new SteamWorkshopSpy
+            {
                 WorkshopItemPublishResult = new WorkshopItemPublishResult(AppId, PublishResult.Failed)
             };
 
-            var sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, CreateValidChangeSet());
+            CreateSteamWorkshopItemTask sut = MakeSutWithWorkshopAndChangeSet(workshopSpy, CreateValidChangeSet());
 
             Action action = () => sut.Run();
 
@@ -138,50 +154,61 @@ namespace EawXBuildTest.Tasks.Steam {
         }
 
         [TestMethod]
-        public void GivenTaskWithoutAppId__WhenRunningTask__ShouldThrowException() {
-            var workshop = new SteamWorkshopDummy();
-            var sut = new CreateSteamWorkshopItemTask(workshop) {
+        public void GivenTaskWithoutAppId__WhenRunningTask__ShouldThrowException()
+        {
+            SteamWorkshopDummy workshop = new SteamWorkshopDummy();
+            CreateSteamWorkshopItemTask sut = new CreateSteamWorkshopItemTask(workshop)
+            {
                 ChangeSet = CreateValidChangeSet()
             };
 
-            var actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
+            InvalidOperationException actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
 
             Assert.AreEqual("No AppId set", actual.Message);
         }
 
         [TestMethod]
-        public void GivenTaskWithoutChangeSet__WhenRunningTask__ShouldThrowException() {
-            var workshop = new SteamWorkshopDummy();
-            var sut = new CreateSteamWorkshopItemTask(workshop) {AppId = AppId};
+        public void GivenTaskWithoutChangeSet__WhenRunningTask__ShouldThrowException()
+        {
+            SteamWorkshopDummy workshop = new SteamWorkshopDummy();
+            CreateSteamWorkshopItemTask sut = new CreateSteamWorkshopItemTask(workshop) {AppId = AppId};
 
-            var actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
+            InvalidOperationException actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
 
             Assert.AreEqual("No change set given", actual.Message);
         }
 
-        private static void AssertSetAppIdThenPublishThenShutdown(SteamWorkshopSpy workshopSpy) {
+        private static void AssertSetAppIdThenPublishThenShutdown(SteamWorkshopSpy workshopSpy)
+        {
             Assert.AreEqual("apd", workshopSpy.CallOrder);
         }
 
-        private static void AssertPublishedWithDefaultSettings(IWorkshopItemChangeSet actual) {
+        private static void AssertPublishedWithDefaultSettings(IWorkshopItemChangeSet actual)
+        {
             Assert.AreEqual("English", actual.Language);
             Assert.AreEqual(WorkshopItemVisibility.Private, actual.Visibility);
         }
 
-        private static SteamWorkshopSpy MakeSteamWorkshopSpy() {
-            return new SteamWorkshopSpy {
+        private static SteamWorkshopSpy MakeSteamWorkshopSpy()
+        {
+            return new SteamWorkshopSpy
+            {
                 WorkshopItemPublishResult = new WorkshopItemPublishResult(1, PublishResult.Ok)
             };
         }
 
-        private static WorkshopItemChangeSetStub CreateValidChangeSet() {
-            return new WorkshopItemChangeSetStub {
+        private static WorkshopItemChangeSetStub CreateValidChangeSet()
+        {
+            return new WorkshopItemChangeSetStub
+            {
                 ChangeSetValidationResult = (true, null)
             };
         }
 
-        private static WorkshopItemChangeSetStub CreateInvalidChangeSet() {
-            return new WorkshopItemChangeSetStub {
+        private static WorkshopItemChangeSetStub CreateInvalidChangeSet()
+        {
+            return new WorkshopItemChangeSetStub
+            {
                 ChangeSetValidationResult = (false, new InvalidOperationException())
             };
         }

--- a/eawx-build-test/Tasks/Steam/UpdateSteamWorkshopItemTaskTest.cs
+++ b/eawx-build-test/Tasks/Steam/UpdateSteamWorkshopItemTaskTest.cs
@@ -7,9 +7,11 @@ using EawXBuild.Tasks.Steam;
 using EawXBuildTest.Steam;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest.Tasks.Steam {
+namespace EawXBuildTest.Tasks.Steam
+{
     [TestClass]
-    public class UpdateSteamWorkshopItemTaskTest {
+    public class UpdateSteamWorkshopItemTaskTest
+    {
         private const uint AppId = 32470;
         private const ulong ItemId = 1234;
         private const string Title = "My Workshop Item";
@@ -20,16 +22,20 @@ namespace EawXBuildTest.Tasks.Steam {
 
         [TestMethod]
         public void
-            GivenTaskWithItemId_Title_Description_Folder_And_Visibility__WhenRunningTask__ShouldPublishWithSettings() {
-            var workshopItemSpy = new WorkshopItemSpy();
-            var workshopSpy = new SteamWorkshopSpy {
+            GivenTaskWithItemId_Title_Description_Folder_And_Visibility__WhenRunningTask__ShouldPublishWithSettings()
+        {
+            WorkshopItemSpy workshopItemSpy = new WorkshopItemSpy();
+            SteamWorkshopSpy workshopSpy = new SteamWorkshopSpy
+            {
                 WorkshopItemsById = {{ItemId, workshopItemSpy}}
             };
 
-            var sut = new UpdateSteamWorkshopItemTask(workshopSpy) {
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshopSpy)
+            {
                 AppId = AppId,
                 ItemId = ItemId,
-                ChangeSet = new WorkshopItemChangeSetStub {
+                ChangeSet = new WorkshopItemChangeSetStub
+                {
                     ChangeSetValidationResult = (true, null),
 
                     Title = Title,
@@ -42,7 +48,7 @@ namespace EawXBuildTest.Tasks.Steam {
 
             sut.Run();
 
-            var actual = workshopItemSpy.ReceivedSettings;
+            IWorkshopItemChangeSet actual = workshopItemSpy.ReceivedSettings;
             Assert.AreEqual(AppId, workshopSpy.AppId);
             Assert.AreEqual(Title, actual.Title);
             Assert.AreEqual(DescriptionFilePath, actual.DescriptionFilePath);
@@ -52,13 +58,17 @@ namespace EawXBuildTest.Tasks.Steam {
         }
 
         [TestMethod]
-        public void GivenValidTask__WhenRunningTask__ShouldWaitForItemQueryToFinishBeforeUpdating() {
-            var callOrderMock = new VerifySteamClientAndWorkshopItemCallOrderMock();
+        public void GivenValidTask__WhenRunningTask__ShouldWaitForItemQueryToFinishBeforeUpdating()
+        {
+            VerifySteamClientAndWorkshopItemCallOrderMock callOrderMock =
+                new VerifySteamClientAndWorkshopItemCallOrderMock();
 
-            var sut = new UpdateSteamWorkshopItemTask(callOrderMock) {
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(callOrderMock)
+            {
                 AppId = AppId,
                 ItemId = ItemId,
-                ChangeSet = new WorkshopItemChangeSetStub {
+                ChangeSet = new WorkshopItemChangeSetStub
+                {
                     ChangeSetValidationResult = (true, null)
                 }
             };
@@ -70,13 +80,16 @@ namespace EawXBuildTest.Tasks.Steam {
 
         [TestMethod]
         [ExpectedException(typeof(InvalidOperationException))]
-        public void GivenTaskWithoutChangeSet__WhenRunningTask__ShouldThrowInvalidOperationException() {
-            var workshopItemStub = new WorkshopItemStub();
-            var workshopStub = new SteamWorkshopStub {
+        public void GivenTaskWithoutChangeSet__WhenRunningTask__ShouldThrowInvalidOperationException()
+        {
+            WorkshopItemStub workshopItemStub = new WorkshopItemStub();
+            SteamWorkshopStub workshopStub = new SteamWorkshopStub
+            {
                 WorkshopItemsById = {{ItemId, workshopItemStub}}
             };
 
-            var sut = new UpdateSteamWorkshopItemTask(workshopStub) {
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshopStub)
+            {
                 ItemId = ItemId
             };
 
@@ -85,13 +98,16 @@ namespace EawXBuildTest.Tasks.Steam {
 
         [TestMethod]
         [ExpectedException(typeof(ProcessFailedException))]
-        public void GivenValidTask__WhenRunningTask_ButPublishFails__ShouldThrowProcessFailedException() {
-            var workshopItemSpy = new WorkshopItemStub {Result = PublishResult.Failed};
-            var workshopStub = new SteamWorkshopStub {
+        public void GivenValidTask__WhenRunningTask_ButPublishFails__ShouldThrowProcessFailedException()
+        {
+            WorkshopItemStub workshopItemSpy = new WorkshopItemStub {Result = PublishResult.Failed};
+            SteamWorkshopStub workshopStub = new SteamWorkshopStub
+            {
                 WorkshopItemsById = {{ItemId, workshopItemSpy}}
             };
 
-            var sut = new UpdateSteamWorkshopItemTask(workshopStub) {
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshopStub)
+            {
                 AppId = AppId,
                 ItemId = ItemId,
                 ChangeSet = CreateValidChangeSet()
@@ -101,13 +117,16 @@ namespace EawXBuildTest.Tasks.Steam {
         }
 
         [TestMethod]
-        public void GivenValidTask__WhenRunningTask_ButPublishFails__ShouldShutdownSteamClient() {
-            var workshopItemSpy = new WorkshopItemStub {Result = PublishResult.Failed};
-            var workshopSpy = new SteamWorkshopSpy {
+        public void GivenValidTask__WhenRunningTask_ButPublishFails__ShouldShutdownSteamClient()
+        {
+            WorkshopItemStub workshopItemSpy = new WorkshopItemStub {Result = PublishResult.Failed};
+            SteamWorkshopSpy workshopSpy = new SteamWorkshopSpy
+            {
                 WorkshopItemsById = {{ItemId, workshopItemSpy}}
             };
 
-            var sut = new UpdateSteamWorkshopItemTask(workshopSpy) {
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshopSpy)
+            {
                 AppId = AppId,
                 ItemId = ItemId,
                 ChangeSet = CreateValidChangeSet()
@@ -121,12 +140,15 @@ namespace EawXBuildTest.Tasks.Steam {
 
         [TestMethod]
         [ExpectedException(typeof(WorkshopItemNotFoundException))]
-        public void GivenTaskWithNonExistingItemId__WhenRunningTask__ShouldThrowWorkshopItemNotFoundException() {
-            var workshopStub = new SteamWorkshopStub {
+        public void GivenTaskWithNonExistingItemId__WhenRunningTask__ShouldThrowWorkshopItemNotFoundException()
+        {
+            SteamWorkshopStub workshopStub = new SteamWorkshopStub
+            {
                 WorkshopItemsById = {{ItemId, null}}
             };
 
-            var sut = new UpdateSteamWorkshopItemTask(workshopStub) {
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshopStub)
+            {
                 AppId = AppId,
                 ItemId = ItemId,
                 ChangeSet = CreateValidChangeSet()
@@ -136,12 +158,15 @@ namespace EawXBuildTest.Tasks.Steam {
         }
 
         [TestMethod]
-        public void GivenTaskWithNonExistingItemId__WhenRunningTask__ShouldShutDownSteamClient() {
-            var workshopSpy = new SteamWorkshopSpy {
+        public void GivenTaskWithNonExistingItemId__WhenRunningTask__ShouldShutDownSteamClient()
+        {
+            SteamWorkshopSpy workshopSpy = new SteamWorkshopSpy
+            {
                 WorkshopItemsById = {{ItemId, null}}
             };
 
-            var sut = new UpdateSteamWorkshopItemTask(workshopSpy) {
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshopSpy)
+            {
                 AppId = AppId,
                 ItemId = ItemId,
                 ChangeSet = CreateValidChangeSet()
@@ -154,68 +179,80 @@ namespace EawXBuildTest.Tasks.Steam {
         }
 
         [TestMethod]
-        public void GivenTaskWithoutAppId__WhenRunningTask__ShouldThrowException() {
-            var workshop = new SteamWorkshopDummy();
-            var sut = new UpdateSteamWorkshopItemTask(workshop) {
+        public void GivenTaskWithoutAppId__WhenRunningTask__ShouldThrowException()
+        {
+            SteamWorkshopDummy workshop = new SteamWorkshopDummy();
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshop)
+            {
                 ItemId = ItemId,
                 ChangeSet = CreateValidChangeSet()
             };
 
-            var actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
+            InvalidOperationException actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
 
             Assert.AreEqual("No AppId set", actual.Message);
         }
 
         [TestMethod]
-        public void GivenTaskWithoutAppId__WhenRunningTask__ShouldNotInitWorkshop() {
-            var workshop = new SteamWorkshopSpy();
-            var sut = new UpdateSteamWorkshopItemTask(workshop) {
+        public void GivenTaskWithoutAppId__WhenRunningTask__ShouldNotInitWorkshop()
+        {
+            SteamWorkshopSpy workshop = new SteamWorkshopSpy();
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshop)
+            {
                 ItemId = ItemId,
                 ChangeSet = CreateValidChangeSet()
             };
 
-            var actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
+            InvalidOperationException actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
 
             Assert.IsFalse(workshop.WasInitialized);
         }
 
         [TestMethod]
-        public void GivenTaskWithoutItemId__WhenRunningTask__ShouldThrowInvalidOperationException() {
-            var workshopDummy = new SteamWorkshopDummy();
-            var sut = new UpdateSteamWorkshopItemTask(workshopDummy) {
+        public void GivenTaskWithoutItemId__WhenRunningTask__ShouldThrowInvalidOperationException()
+        {
+            SteamWorkshopDummy workshopDummy = new SteamWorkshopDummy();
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshopDummy)
+            {
                 AppId = AppId,
                 ChangeSet = CreateValidChangeSet()
             };
 
-            var actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
+            InvalidOperationException actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
 
             Assert.AreEqual("No ItemId set", actual.Message);
         }
 
         [TestMethod]
-        public void GivenTaskWithoutItemId__WhenRunningTask__ShouldNotInitWorkshop() {
-            var workshop = new SteamWorkshopSpy();
-            var sut = new UpdateSteamWorkshopItemTask(workshop) {
+        public void GivenTaskWithoutItemId__WhenRunningTask__ShouldNotInitWorkshop()
+        {
+            SteamWorkshopSpy workshop = new SteamWorkshopSpy();
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshop)
+            {
                 AppId = AppId,
                 ChangeSet = CreateValidChangeSet()
             };
 
-            var actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
+            InvalidOperationException actual = Assert.ThrowsException<InvalidOperationException>(() => sut.Run());
 
             Assert.IsFalse(workshop.WasInitialized);
         }
 
         [TestMethod]
-        public void GivenTaskWithInvalidNewChangeSet__WhenRunningTask__ShouldThrowExceptionFromChangeSet() {
-            var workshopItemSpy = new WorkshopItemSpy();
-            var workshopStub = new SteamWorkshopStub {
+        public void GivenTaskWithInvalidNewChangeSet__WhenRunningTask__ShouldThrowExceptionFromChangeSet()
+        {
+            WorkshopItemSpy workshopItemSpy = new WorkshopItemSpy();
+            SteamWorkshopStub workshopStub = new SteamWorkshopStub
+            {
                 WorkshopItemsById = {{ItemId, workshopItemSpy}}
             };
 
-            var sut = new UpdateSteamWorkshopItemTask(workshopStub) {
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshopStub)
+            {
                 AppId = AppId,
                 ItemId = ItemId,
-                ChangeSet = new WorkshopItemChangeSetStub {
+                ChangeSet = new WorkshopItemChangeSetStub
+                {
                     ChangeSetValidationResult = (false, new FormatException())
                 }
             };
@@ -226,16 +263,20 @@ namespace EawXBuildTest.Tasks.Steam {
         }
 
         [TestMethod]
-        public void GivenTaskWithInvalidNewChangeSet__WhenRunningTask__ShouldNotUpdateItem() {
-            var workshopItemSpy = new WorkshopItemSpy();
-            var workshopStub = new SteamWorkshopStub {
+        public void GivenTaskWithInvalidNewChangeSet__WhenRunningTask__ShouldNotUpdateItem()
+        {
+            WorkshopItemSpy workshopItemSpy = new WorkshopItemSpy();
+            SteamWorkshopStub workshopStub = new SteamWorkshopStub
+            {
                 WorkshopItemsById = {{ItemId, workshopItemSpy}}
             };
 
-            var sut = new UpdateSteamWorkshopItemTask(workshopStub) {
+            UpdateSteamWorkshopItemTask sut = new UpdateSteamWorkshopItemTask(workshopStub)
+            {
                 AppId = AppId,
                 ItemId = ItemId,
-                ChangeSet = new WorkshopItemChangeSetStub {
+                ChangeSet = new WorkshopItemChangeSetStub
+                {
                     ChangeSetValidationResult = (false, new FormatException())
                 }
             };
@@ -247,8 +288,10 @@ namespace EawXBuildTest.Tasks.Steam {
         }
 
 
-        private static WorkshopItemChangeSetStub CreateValidChangeSet() {
-            return new WorkshopItemChangeSetStub {
+        private static WorkshopItemChangeSetStub CreateValidChangeSet()
+        {
+            return new WorkshopItemChangeSetStub
+            {
                 ChangeSetValidationResult = (true, null)
             };
         }

--- a/eawx-build-test/TestAttributes.cs
+++ b/eawx-build-test/TestAttributes.cs
@@ -1,35 +1,43 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace EawXBuildTest {
-    public class PlatformSpecificTestMethod : TestMethodAttribute {
-        public PlatformSpecificTestMethod(params string[] platforms) {
+namespace EawXBuildTest
+{
+    public class PlatformSpecificTestMethod : TestMethodAttribute
+    {
+        public PlatformSpecificTestMethod(params string[] platforms)
+        {
             Platforms = platforms.Select(platformName => OSPlatform.Create(platformName.ToUpper()));
         }
 
-        public override TestResult[] Execute(ITestMethod testMethod) {
-            var platformMatches = Platforms.Any(RuntimeInformation.IsOSPlatform);
+        public IEnumerable<OSPlatform> Platforms { get; }
+
+        public override TestResult[] Execute(ITestMethod testMethod)
+        {
+            bool platformMatches = Platforms.Any(RuntimeInformation.IsOSPlatform);
             return !platformMatches
                 ? new[] {new TestResult {Outcome = UnitTestOutcome.Inconclusive}}
                 : base.Execute(testMethod);
         }
-
-        public IEnumerable<OSPlatform> Platforms { get; }
     }
 
-    public class TestMethodWithRequiredEnvironmentVariable : TestMethodAttribute {
-        private readonly string _variableName;
+    public class TestMethodWithRequiredEnvironmentVariable : TestMethodAttribute
+    {
         private readonly string _requiredValue;
+        private readonly string _variableName;
 
-        public TestMethodWithRequiredEnvironmentVariable(string variableName, string requiredValue) {
+        public TestMethodWithRequiredEnvironmentVariable(string variableName, string requiredValue)
+        {
             _variableName = variableName;
             _requiredValue = requiredValue;
         }
 
-        public override TestResult[] Execute(ITestMethod testMethod) {
-            var variable = System.Environment.GetEnvironmentVariable(_variableName);
+        public override TestResult[] Execute(ITestMethod testMethod)
+        {
+            string? variable = Environment.GetEnvironmentVariable(_variableName);
 
             return variable == null || !variable.Equals(_requiredValue)
                 ? new[] {new TestResult {Outcome = UnitTestOutcome.Inconclusive}}

--- a/eawx-build-test/TestUtility.cs
+++ b/eawx-build-test/TestUtility.cs
@@ -44,8 +44,8 @@ namespace EawXBuildTest {
                     options.AddFilter<ConsoleLoggerProvider>(null, verbose ? LogLevel.Trace : LogLevel.Warning);
                 });
             var lsp = serviceCollection.BuildServiceProvider();
-            serviceCollection.AddTransient<IIOService, IOService>(s =>
-                new IOService(mockFileSystem, lsp.GetRequiredService<ILoggerFactory>()));
+            serviceCollection.AddTransient<IIOHelperService, IOHelperService>(s =>
+                new IOHelperService(mockFileSystem, lsp.GetRequiredService<ILoggerFactory>()));
             serviceCollection.AddTransient<IBuildComponentFactory, BuildComponentFactory>(s =>
                 new BuildComponentFactory(
                     lsp.GetRequiredService<ILoggerFactory>().CreateLogger<BuildComponentFactory>()));

--- a/eawx-build-test/TestUtility.cs
+++ b/eawx-build-test/TestUtility.cs
@@ -10,40 +10,49 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Logging.Debug;
 
-namespace EawXBuildTest {
-    public static class TestUtility {
+namespace EawXBuildTest
+{
+    public static class TestUtility
+    {
         public const string TEST_TYPE_HOLY = "Holy Test";
         public const string TEST_TYPE_UTILITY = "Utility Test";
 
-        public static bool IsWindows() {
+        public static bool IsWindows()
+        {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
 
-        public static bool IsLinuxOrMacOS() {
+        public static bool IsLinuxOrMacOS()
+        {
             return IsLinux() || IsMacOS();
         }
 
-        public static bool IsLinux() {
+        public static bool IsLinux()
+        {
             return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         }
 
-        public static bool IsMacOS() {
+        public static bool IsMacOS()
+        {
             return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         }
 
-        public static IServiceCollection GetConfiguredServiceCollection(bool verbose = true) {
-            GetConfiguredMockFileSystem(out var mockFileSystem,
+        public static IServiceCollection GetConfiguredServiceCollection(bool verbose = true)
+        {
+            GetConfiguredMockFileSystem(out MockFileSystem mockFileSystem,
                 out _);
             IServiceCollection serviceCollection = new ServiceCollection();
-            serviceCollection.AddLogging(config => {
+            serviceCollection.AddLogging(config =>
+                {
                     config.AddDebug();
                     config.AddConsole();
                 })
-                .Configure<LoggerFilterOptions>(options => {
+                .Configure<LoggerFilterOptions>(options =>
+                {
                     options.AddFilter<DebugLoggerProvider>(null, LogLevel.Trace);
                     options.AddFilter<ConsoleLoggerProvider>(null, verbose ? LogLevel.Trace : LogLevel.Warning);
                 });
-            var lsp = serviceCollection.BuildServiceProvider();
+            ServiceProvider lsp = serviceCollection.BuildServiceProvider();
             serviceCollection.AddTransient<IIOHelperService, IOHelperService>(s =>
                 new IOHelperService(mockFileSystem, lsp.GetRequiredService<ILoggerFactory>()));
             serviceCollection.AddTransient<IBuildComponentFactory, BuildComponentFactory>(s =>
@@ -54,10 +63,12 @@ namespace EawXBuildTest {
         }
 
         public static void GetConfiguredMockFileSystem(out MockFileSystem mockFileSystem,
-            out FileSystemAssertions fileSystemAssertions) {
+            out FileSystemAssertions fileSystemAssertions)
+        {
             mockFileSystem = null;
             fileSystemAssertions = null;
-            if (IsWindows()) {
+            if (IsWindows())
+            {
                 mockFileSystem = new MockFileSystem();
                 mockFileSystem.AddDirectory("C:/data/test/path");
                 mockFileSystem.AddDirectory("C:/data/path");
@@ -70,7 +81,8 @@ namespace EawXBuildTest {
                 fileSystemAssertions.AssertFileExists("C:/data/path/test.xml");
             }
 
-            if (IsLinuxOrMacOS()) {
+            if (IsLinuxOrMacOS())
+            {
                 mockFileSystem = new MockFileSystem();
                 mockFileSystem.AddDirectory("/mnt/c/data/test/path");
                 mockFileSystem.AddDirectory("/mnt/c/data/path");

--- a/eawx-build-test/eawx-build-test.csproj
+++ b/eawx-build-test/eawx-build-test.csproj
@@ -1,21 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <RootNamespace>EawXBuildTest</RootNamespace>
-
     <IsPackable>false</IsPackable>
-
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-
     <PackageVersion>0.1.0</PackageVersion>
-
     <AssemblyVersion>0.1.0</AssemblyVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="3.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
@@ -23,15 +21,12 @@
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.29" />
     <PackageReference Include="semver" Version="2.0.6" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\eawx-build\eawx-build.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="Configuration\Xml" />
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Facepunch.Steamworks.Posix, Culture=neutral, PublicKeyToken=null" Condition="$([MSBuild]::IsOsPlatform('Linux'))">
       <HintPath>..\eawx-build\Steam\Facepunch.Steamworks\2.3.2\Facepunch.Steamworks.Posix.dll</HintPath>
@@ -43,11 +38,12 @@
       <HintPath>..\eawx-build\Steam\Facepunch.Steamworks\2.3.2\Facepunch.Steamworks.Win64.dll</HintPath>
     </Reference>
   </ItemGroup>
-
   <Target Name="CopyLibSteam" AfterTargets="AfterBuild">
     <Copy SourceFiles="..\eawx-build\Steam\Facepunch.Steamworks\2.3.2\SteamAPI/libsteam_api.so" DestinationFolder="$(OutDir)" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
     <Copy SourceFiles="..\eawx-build\Steam\Facepunch.Steamworks\2.3.2\SteamAPI/libsteam_api.bundle" DestinationFolder="$(OutDir)" Condition="$([MSBuild]::IsOsPlatform('OSX'))" />
     <Copy SourceFiles="..\eawx-build\Steam\Facepunch.Steamworks\2.3.2\SteamAPI/steam_api64.dll" DestinationFolder="$(OutDir)" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
   </Target>
-
+  <ItemGroup>    
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
 </Project>

--- a/eawx-build.sln.DotSettings
+++ b/eawx-build.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Constants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AA_BB" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="AA_BB" /&gt;</s:String>

--- a/eawx-build/Configuration/CLI/IOptions.cs
+++ b/eawx-build/Configuration/CLI/IOptions.cs
@@ -1,7 +1,9 @@
 using CommandLine;
 
-namespace EawXBuild.Configuration.CLI {
-    public interface IOptions {
+namespace EawXBuild.Configuration.CLI
+{
+    public interface IOptions
+    {
         [Option('l', "lua", Default = false, Group = "backend-lua",
             HelpText = "Run the CI Tool with a lua-based configuration.")]
         public bool BackendLua { get; set; }

--- a/eawx-build/Configuration/CLI/NewOptions.cs
+++ b/eawx-build/Configuration/CLI/NewOptions.cs
@@ -1,8 +1,10 @@
 using CommandLine;
 
-namespace EawXBuild.Configuration.CLI {
-    [Verb("new", false, HelpText = "Create a new default eaw-ci project.")]
-    public class NewOptions : IOptions {
+namespace EawXBuild.Configuration.CLI
+{
+    [Verb("new", HelpText = "Create a new default eaw-ci project.")]
+    public class NewOptions : IOptions
+    {
         public bool BackendLua { get; set; }
         public bool BackendXml { get; set; }
         public string ConfigPath { get; set; }

--- a/eawx-build/Configuration/CLI/RunOptions.cs
+++ b/eawx-build/Configuration/CLI/RunOptions.cs
@@ -1,20 +1,22 @@
 using CommandLine;
 
-namespace EawXBuild.Configuration.CLI {
+namespace EawXBuild.Configuration.CLI
+{
     [Verb("run", true, HelpText = "Run a CI project from an optionally specified configuration file.")]
-    internal class RunOptions : IOptions {
+    internal class RunOptions : IOptions
+    {
+        [Option('p', "project", Required = true, HelpText = "Name of the CI project to run.")]
+        public string ProjectName { get; set; }
+
+        [Option('j', "job", Required = false, HelpText = "Name of a job specified within a CI project to run.")]
+        public string JobName { get; set; }
+
         public bool BackendLua { get; set; }
 
         public bool BackendXml { get; set; }
         public string ConfigPath { get; set; }
 
         public ConfigVersion Version { get; set; }
-
-        [Option('p', "project", Required = true, HelpText = "Name of the CI project to run.")]
-        public string ProjectName { get; set; }
-
-        [Option('j', "job", Required = false, HelpText = "Name of a job specified within a CI project to run.")]
-        public string JobName { get; set; }
 
         public bool Verbose { get; set; }
     }

--- a/eawx-build/Configuration/CLI/ValidateOptions.cs
+++ b/eawx-build/Configuration/CLI/ValidateOptions.cs
@@ -1,8 +1,10 @@
 using CommandLine;
 
-namespace EawXBuild.Configuration.CLI {
-    [Verb("validate", false, HelpText = "Validates a given configuration file.")]
-    public class ValidateOptions : IOptions {
+namespace EawXBuild.Configuration.CLI
+{
+    [Verb("validate", HelpText = "Validates a given configuration file.")]
+    public class ValidateOptions : IOptions
+    {
         public bool BackendLua { get; set; }
         public bool BackendXml { get; set; }
         public string ConfigPath { get; set; }

--- a/eawx-build/Configuration/ConfigVersion.cs
+++ b/eawx-build/Configuration/ConfigVersion.cs
@@ -1,6 +1,8 @@
-namespace EawXBuild.Configuration {
-    public enum ConfigVersion {
+namespace EawXBuild.Configuration
+{
+    public enum ConfigVersion
+    {
         Invalid,
-        V1,
+        V1
     }
 }

--- a/eawx-build/Configuration/ConfigurationUtility.cs
+++ b/eawx-build/Configuration/ConfigurationUtility.cs
@@ -1,37 +1,38 @@
 using System.Linq;
 using Semver;
 
-namespace EawXBuild.Configuration {
-    internal static class ConfigurationUtility {
+namespace EawXBuild.Configuration
+{
+    internal static class ConfigurationUtility
+    {
         private static readonly int[] SUPPORTED_MAJOR_VERSIONS = {1};
 
-        internal static bool IsVersionMatch(string versionString, ConfigVersion version) {
-            if (IsVersionInvalid(versionString)) {
-                return version == ConfigVersion.Invalid;
-            }
+        internal static bool IsVersionMatch(string versionString, ConfigVersion version)
+        {
+            if (IsVersionInvalid(versionString)) return version == ConfigVersion.Invalid;
 
             SemVersion.TryParse(versionString, out SemVersion semVer, true);
-            return version switch {
+            return version switch
+            {
                 ConfigVersion.V1 => semVer.Major == 1,
                 _ => false
             };
         }
 
-        private static bool IsVersionInvalid(string versionString) {
-            if (!SemVersion.TryParse(versionString, out SemVersion semVer, true)) {
-                return true;
-            }
+        private static bool IsVersionInvalid(string versionString)
+        {
+            if (!SemVersion.TryParse(versionString, out SemVersion semVer, true)) return true;
 
             return !SUPPORTED_MAJOR_VERSIONS.Contains(semVer.Major);
         }
 
-        internal static ConfigVersion GetConfigVersionInternal(string versionString) {
-            if (IsVersionInvalid(versionString)) {
-                return ConfigVersion.Invalid;
-            }
+        internal static ConfigVersion GetConfigVersionInternal(string versionString)
+        {
+            if (IsVersionInvalid(versionString)) return ConfigVersion.Invalid;
 
             SemVersion.TryParse(versionString, out SemVersion semVer, true);
-            return semVer.Major switch {
+            return semVer.Major switch
+            {
                 1 => ConfigVersion.V1,
                 _ => ConfigVersion.Invalid
             };

--- a/eawx-build/Configuration/FrontendAgnostic/BaseSteamWorkshopTaskBuilder.cs
+++ b/eawx-build/Configuration/FrontendAgnostic/BaseSteamWorkshopTaskBuilder.cs
@@ -5,19 +5,24 @@ using EawXBuild.Core;
 using EawXBuild.Steam;
 using EawXBuild.Tasks.Steam;
 
-namespace EawXBuild.Configuration.FrontendAgnostic {
-    public abstract class BaseSteamWorkshopTaskBuilder : ITaskBuilder {
-        protected SteamWorkshopTask Task;
+namespace EawXBuild.Configuration.FrontendAgnostic
+{
+    public abstract class BaseSteamWorkshopTaskBuilder : ITaskBuilder
+    {
         protected readonly IWorkshopItemChangeSet ChangeSet;
+        protected SteamWorkshopTask Task;
 
-        protected BaseSteamWorkshopTaskBuilder() {
-            var fileSystem = new FileSystem();
+        protected BaseSteamWorkshopTaskBuilder()
+        {
+            FileSystem fileSystem = new FileSystem();
             ChangeSet = new WorkshopItemChangeSet(fileSystem);
         }
 
-        public virtual ITaskBuilder With(string name, object value) {
+        public virtual ITaskBuilder With(string name, object value)
+        {
             Task ??= CreateTaskWithChangeSet(ChangeSet);
-            switch (name) {
+            switch (name)
+            {
                 case "AppId":
                     Task.AppId = Convert.ToUInt32(value);
                     break;
@@ -47,10 +52,11 @@ namespace EawXBuild.Configuration.FrontendAgnostic {
             return this;
         }
 
-        protected abstract SteamWorkshopTask CreateTaskWithChangeSet(IWorkshopItemChangeSet changeSet);
-
-        public ITask Build() {
+        public ITask Build()
+        {
             return Task;
         }
+
+        protected abstract SteamWorkshopTask CreateTaskWithChangeSet(IWorkshopItemChangeSet changeSet);
     }
 }

--- a/eawx-build/Configuration/FrontendAgnostic/BuildComponentFactory.cs
+++ b/eawx-build/Configuration/FrontendAgnostic/BuildComponentFactory.cs
@@ -4,8 +4,10 @@ using EawXBuild.Native;
 using EawXBuild.Tasks;
 using Microsoft.Extensions.Logging;
 
-namespace EawXBuild.Configuration.FrontendAgnostic {
-    internal enum Tasks {
+namespace EawXBuild.Configuration.FrontendAgnostic
+{
+    internal enum Tasks
+    {
         Clean,
         Copy,
         CreateSteamWorkshopItem,
@@ -14,25 +16,31 @@ namespace EawXBuild.Configuration.FrontendAgnostic {
         UpdateSteamWorkshopItem
     }
 
-    public class BuildComponentFactory : IBuildComponentFactory {
-        private readonly ILogger _logger;
+    public class BuildComponentFactory : IBuildComponentFactory
+    {
         private readonly FileLinkerFactory _fileLinkerFactory = new FileLinkerFactory();
+        private readonly ILogger _logger;
 
-        public BuildComponentFactory(ILogger logger = null) {
+        public BuildComponentFactory(ILogger logger = null)
+        {
             _logger = logger;
         }
 
-        public IProject MakeProject() {
+        public IProject MakeProject()
+        {
             return new Project();
         }
 
-        public IJob MakeJob(string name) {
+        public IJob MakeJob(string name)
+        {
             return new Job(name);
         }
 
-        public ITaskBuilder Task(string taskTypeName) {
-            var taskType = ParseTaskTypeName(taskTypeName);
-            return taskType switch {
+        public ITaskBuilder Task(string taskTypeName)
+        {
+            Tasks taskType = ParseTaskTypeName(taskTypeName);
+            return taskType switch
+            {
                 Tasks.RunProgram => new RunProcessTaskBuilder(),
                 Tasks.Clean => new CleanTaskBuilder(),
                 Tasks.Copy => new CopyTaskBuilder(new CopyPolicy()),
@@ -43,11 +51,14 @@ namespace EawXBuild.Configuration.FrontendAgnostic {
             };
         }
 
-        private static Tasks ParseTaskTypeName(string taskTypeName) {
-            try {
+        private static Tasks ParseTaskTypeName(string taskTypeName)
+        {
+            try
+            {
                 return Enum.Parse<Tasks>(taskTypeName);
             }
-            catch (ArgumentException) {
+            catch (ArgumentException)
+            {
                 throw new InvalidOperationException($"Unknown Task type: {taskTypeName}");
             }
         }

--- a/eawx-build/Configuration/FrontendAgnostic/CleanTaskBuilder.cs
+++ b/eawx-build/Configuration/FrontendAgnostic/CleanTaskBuilder.cs
@@ -3,16 +3,21 @@ using System.IO.Abstractions;
 using EawXBuild.Core;
 using EawXBuild.Tasks;
 
-namespace EawXBuild.Configuration.FrontendAgnostic {
-    public class CleanTaskBuilder : ITaskBuilder {
+namespace EawXBuild.Configuration.FrontendAgnostic
+{
+    public class CleanTaskBuilder : ITaskBuilder
+    {
         private readonly CleanTask _cleanTask;
 
-        public CleanTaskBuilder(IFileSystem fileSystem = null) {
+        public CleanTaskBuilder(IFileSystem fileSystem = null)
+        {
             _cleanTask = new CleanTask(fileSystem ?? new FileSystem());
         }
 
-        public ITaskBuilder With(string name, object value) {
-            switch (name) {
+        public ITaskBuilder With(string name, object value)
+        {
+            switch (name)
+            {
                 case "Id":
                     _cleanTask.Id = (string) value;
                     break;
@@ -29,7 +34,8 @@ namespace EawXBuild.Configuration.FrontendAgnostic {
             return this;
         }
 
-        public ITask Build() {
+        public ITask Build()
+        {
             return _cleanTask;
         }
     }

--- a/eawx-build/Configuration/FrontendAgnostic/CopyTaskBuilder.cs
+++ b/eawx-build/Configuration/FrontendAgnostic/CopyTaskBuilder.cs
@@ -3,16 +3,21 @@ using System.IO.Abstractions;
 using EawXBuild.Core;
 using EawXBuild.Tasks;
 
-namespace EawXBuild.Configuration.FrontendAgnostic {
-    public class CopyTaskBuilder : ITaskBuilder {
+namespace EawXBuild.Configuration.FrontendAgnostic
+{
+    public class CopyTaskBuilder : ITaskBuilder
+    {
         private readonly CopyTask _copyTask;
 
-        public CopyTaskBuilder(ICopyPolicy copyPolicy, IFileSystem fileSystem = null) {
+        public CopyTaskBuilder(ICopyPolicy copyPolicy, IFileSystem fileSystem = null)
+        {
             _copyTask = new CopyTask(copyPolicy, fileSystem ?? new FileSystem());
         }
 
-        public ITaskBuilder With(string name, object value) {
-            switch (name) {
+        public ITaskBuilder With(string name, object value)
+        {
+            switch (name)
+            {
                 case "Id":
                     _copyTask.Id = (string) value;
                     break;
@@ -41,7 +46,8 @@ namespace EawXBuild.Configuration.FrontendAgnostic {
             return this;
         }
 
-        public ITask Build() {
+        public ITask Build()
+        {
             return _copyTask;
         }
     }

--- a/eawx-build/Configuration/FrontendAgnostic/CreateSteamWorkshopItemTaskBuilder.cs
+++ b/eawx-build/Configuration/FrontendAgnostic/CreateSteamWorkshopItemTaskBuilder.cs
@@ -2,10 +2,14 @@ using EawXBuild.Steam;
 using EawXBuild.Steam.Facepunch.Adapters;
 using EawXBuild.Tasks.Steam;
 
-namespace EawXBuild.Configuration.FrontendAgnostic {
-    public class CreateSteamWorkshopItemTaskBuilder : BaseSteamWorkshopTaskBuilder {
-        protected override SteamWorkshopTask CreateTaskWithChangeSet(IWorkshopItemChangeSet changeSet) {
-            return new CreateSteamWorkshopItemTask(FacepunchSteamWorkshopAdapter.Instance) {
+namespace EawXBuild.Configuration.FrontendAgnostic
+{
+    public class CreateSteamWorkshopItemTaskBuilder : BaseSteamWorkshopTaskBuilder
+    {
+        protected override SteamWorkshopTask CreateTaskWithChangeSet(IWorkshopItemChangeSet changeSet)
+        {
+            return new CreateSteamWorkshopItemTask(FacepunchSteamWorkshopAdapter.Instance)
+            {
                 ChangeSet = changeSet
             };
         }

--- a/eawx-build/Configuration/FrontendAgnostic/IBuildConfigParser.cs
+++ b/eawx-build/Configuration/FrontendAgnostic/IBuildConfigParser.cs
@@ -1,13 +1,15 @@
 using System.Collections.Generic;
 using EawXBuild.Core;
 
-namespace EawXBuild.Configuration.FrontendAgnostic {
-    public interface IBuildConfigParser {
-        IEnumerable<IProject> Parse(string filePath);
-        bool TestIsValidConfiguration(string filePath);
+namespace EawXBuild.Configuration.FrontendAgnostic
+{
+    public interface IBuildConfigParser
+    {
         ConfigVersion Version { get; }
         string ConfiguredFileExtension { get; }
 
         public string DefaultConfigFile { get; }
+        IEnumerable<IProject> Parse(string filePath);
+        bool TestIsValidConfiguration(string filePath);
     }
 }

--- a/eawx-build/Configuration/FrontendAgnostic/RunProcessTaskBuilder.cs
+++ b/eawx-build/Configuration/FrontendAgnostic/RunProcessTaskBuilder.cs
@@ -4,16 +4,21 @@ using EawXBuild.Core;
 using EawXBuild.Services.Process;
 using EawXBuild.Tasks;
 
-namespace EawXBuild.Configuration.FrontendAgnostic {
-    public class RunProcessTaskBuilder : ITaskBuilder {
+namespace EawXBuild.Configuration.FrontendAgnostic
+{
+    public class RunProcessTaskBuilder : ITaskBuilder
+    {
         private readonly RunProcessTask _runProcessTask;
 
-        public RunProcessTaskBuilder(IFileSystem fileSystem = null) {
+        public RunProcessTaskBuilder(IFileSystem fileSystem = null)
+        {
             _runProcessTask = new RunProcessTask(new ProcessRunner(), fileSystem ?? new FileSystem());
         }
 
-        public ITaskBuilder With(string name, object value) {
-            switch (name) {
+        public ITaskBuilder With(string name, object value)
+        {
+            switch (name)
+            {
                 case "Id":
                     _runProcessTask.Id = (string) value;
                     break;
@@ -39,7 +44,8 @@ namespace EawXBuild.Configuration.FrontendAgnostic {
             return this;
         }
 
-        public ITask Build() {
+        public ITask Build()
+        {
             return _runProcessTask;
         }
     }

--- a/eawx-build/Configuration/FrontendAgnostic/UpdateSteamWorkshopItemTaskBuilder.cs
+++ b/eawx-build/Configuration/FrontendAgnostic/UpdateSteamWorkshopItemTaskBuilder.cs
@@ -4,19 +4,24 @@ using EawXBuild.Steam;
 using EawXBuild.Steam.Facepunch.Adapters;
 using EawXBuild.Tasks.Steam;
 
-namespace EawXBuild.Configuration.FrontendAgnostic {
-    public class UpdateSteamWorkshopItemTaskBuilder : BaseSteamWorkshopTaskBuilder {
-        public override ITaskBuilder With(string name, object value) {
+namespace EawXBuild.Configuration.FrontendAgnostic
+{
+    public class UpdateSteamWorkshopItemTaskBuilder : BaseSteamWorkshopTaskBuilder
+    {
+        public override ITaskBuilder With(string name, object value)
+        {
             Task ??= CreateTaskWithChangeSet(ChangeSet);
 
             if (!name.Equals("ItemId")) return base.With(name, value);
-            var updateTask = (UpdateSteamWorkshopItemTask) Task;
+            UpdateSteamWorkshopItemTask updateTask = (UpdateSteamWorkshopItemTask) Task;
             updateTask.ItemId = Convert.ToUInt64(value);
             return this;
         }
 
-        protected override SteamWorkshopTask CreateTaskWithChangeSet(IWorkshopItemChangeSet changeSet) {
-            return new UpdateSteamWorkshopItemTask(FacepunchSteamWorkshopAdapter.Instance) {
+        protected override SteamWorkshopTask CreateTaskWithChangeSet(IWorkshopItemChangeSet changeSet)
+        {
+            return new UpdateSteamWorkshopItemTask(FacepunchSteamWorkshopAdapter.Instance)
+            {
                 ChangeSet = changeSet
             };
         }

--- a/eawx-build/Configuration/Lua/v1/EawCiLuaEnvironment.cs
+++ b/eawx-build/Configuration/Lua/v1/EawCiLuaEnvironment.cs
@@ -3,54 +3,64 @@ using EawXBuild.Core;
 using EawXBuild.Steam;
 using NLua;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public class EawCiLuaEnvironment {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public class EawCiLuaEnvironment
+    {
         private readonly IBuildComponentFactory _factory;
 
-        public List<IProject> Projects { get; } = new List<IProject>();
-
-        public EawCiLuaEnvironment(IBuildComponentFactory factory, ILuaParser parser) {
+        public EawCiLuaEnvironment(IBuildComponentFactory factory, ILuaParser parser)
+        {
             _factory = factory;
-            var luaTable = parser.NewTable("visibility");
+            LuaTable luaTable = parser.NewTable("visibility");
             luaTable["private"] = WorkshopItemVisibility.Private;
             luaTable["public"] = WorkshopItemVisibility.Public;
         }
 
+        public List<IProject> Projects { get; } = new List<IProject>();
+
         [LuaGlobal(Name = "project")]
-        public LuaProject MakeLuaProject(string name) {
-            var luaProject = new LuaProject(name, _factory);
+        public LuaProject MakeLuaProject(string name)
+        {
+            LuaProject luaProject = new LuaProject(name, _factory);
             Projects.Add(luaProject.Project);
             return luaProject;
         }
 
 
         [LuaGlobal(Name = "copy")]
-        public ILuaTask Copy(string source, string target) {
+        public ILuaTask Copy(string source, string target)
+        {
             return new LuaCopyTask(_factory.Task("Copy"), source, target);
         }
 
         [LuaGlobal(Name = "link")]
-        public ILuaTask Link(string source, string target) {
+        public ILuaTask Link(string source, string target)
+        {
             return new LuaCopyTask(_factory.Task("SoftCopy"), source, target);
         }
 
         [LuaGlobal(Name = "clean")]
-        public ILuaTask Clean(string target) {
+        public ILuaTask Clean(string target)
+        {
             return new LuaCleanTask(_factory.Task("Clean"), target);
         }
 
         [LuaGlobal(Name = "run_process")]
-        public ILuaTask RunProcess(string path) {
+        public ILuaTask RunProcess(string path)
+        {
             return new LuaRunProcessTask(_factory.Task("RunProgram"), path);
         }
 
         [LuaGlobal(Name = "create_steam_workshop_item")]
-        public ILuaTask CreateSteamWorkshopItem(LuaTable luaTable) {
+        public ILuaTask CreateSteamWorkshopItem(LuaTable luaTable)
+        {
             return new LuaCreateSteamWorkshopItemTask(_factory.Task("CreateSteamWorkshopItem"), luaTable);
         }
 
         [LuaGlobal(Name = "update_steam_workshop_item")]
-        public ILuaTask UpdateSteamWorkshopItem(LuaTable luaTable) {
+        public ILuaTask UpdateSteamWorkshopItem(LuaTable luaTable)
+        {
             return new LuaUpdateSteamWorkshopItemTask(_factory.Task("UpdateSteamWorkshopItem"), luaTable);
         }
     }

--- a/eawx-build/Configuration/Lua/v1/ILuaParser.cs
+++ b/eawx-build/Configuration/Lua/v1/ILuaParser.cs
@@ -1,8 +1,10 @@
 using System;
 using NLua;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public interface ILuaParser : IDisposable {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public interface ILuaParser : IDisposable
+    {
         LuaTable NewTable(string fullPath);
 
         void RegisterObject(object obj);

--- a/eawx-build/Configuration/Lua/v1/ILuaTask.cs
+++ b/eawx-build/Configuration/Lua/v1/ILuaTask.cs
@@ -1,7 +1,9 @@
 using EawXBuild.Core;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public interface ILuaTask {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public interface ILuaTask
+    {
         public ITask Task { get; }
     }
 }

--- a/eawx-build/Configuration/Lua/v1/LuaBuildConfigParser.cs
+++ b/eawx-build/Configuration/Lua/v1/LuaBuildConfigParser.cs
@@ -3,28 +3,32 @@ using System.Collections.Generic;
 using EawXBuild.Configuration.FrontendAgnostic;
 using EawXBuild.Core;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public class LuaBuildConfigParser : IBuildConfigParser {
-        private readonly ILuaParser _luaParser;
-        private readonly IBuildComponentFactory _factory;
-
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public class LuaBuildConfigParser : IBuildConfigParser
+    {
         private const string FileExtension = ".lua";
         private const string DefaultLua = "";
         private const ConfigVersion ConfigVersion = Configuration.ConfigVersion.V1;
+        private readonly IBuildComponentFactory _factory;
+        private readonly ILuaParser _luaParser;
 
-        public LuaBuildConfigParser(ILuaParser luaParser, IBuildComponentFactory factory) {
+        public LuaBuildConfigParser(ILuaParser luaParser, IBuildComponentFactory factory)
+        {
             _luaParser = luaParser;
             _factory = factory;
         }
 
-        public IEnumerable<IProject> Parse(string filePath) {
-            var luaEnvironment = new EawCiLuaEnvironment(_factory, _luaParser);
+        public IEnumerable<IProject> Parse(string filePath)
+        {
+            EawCiLuaEnvironment luaEnvironment = new EawCiLuaEnvironment(_factory, _luaParser);
             _luaParser.RegisterObject(luaEnvironment);
             _luaParser.DoFile(filePath);
             return luaEnvironment.Projects;
         }
 
-        public bool TestIsValidConfiguration(string filePath) {
+        public bool TestIsValidConfiguration(string filePath)
+        {
             throw new NotImplementedException();
         }
 

--- a/eawx-build/Configuration/Lua/v1/LuaCleanTask.cs
+++ b/eawx-build/Configuration/Lua/v1/LuaCleanTask.cs
@@ -1,10 +1,13 @@
 using EawXBuild.Core;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public class LuaCleanTask : ILuaTask {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public class LuaCleanTask : ILuaTask
+    {
         private readonly ITaskBuilder _taskBuilder;
 
-        public LuaCleanTask(ITaskBuilder taskBuilder, string path) {
+        public LuaCleanTask(ITaskBuilder taskBuilder, string path)
+        {
             _taskBuilder = taskBuilder;
             _taskBuilder.With("Path", path);
         }

--- a/eawx-build/Configuration/Lua/v1/LuaCopyTask.cs
+++ b/eawx-build/Configuration/Lua/v1/LuaCopyTask.cs
@@ -1,10 +1,13 @@
 using EawXBuild.Core;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public class LuaCopyTask : ILuaTask {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public class LuaCopyTask : ILuaTask
+    {
         private readonly ITaskBuilder _taskBuilder;
 
-        public LuaCopyTask(ITaskBuilder taskBuilder, string source, string target) {
+        public LuaCopyTask(ITaskBuilder taskBuilder, string source, string target)
+        {
             _taskBuilder = taskBuilder;
             _taskBuilder
                 .With("CopyFromPath", source)
@@ -13,17 +16,20 @@ namespace EawXBuild.Configuration.Lua.v1 {
 
         public ITask Task => _taskBuilder.Build();
 
-        public LuaCopyTask overwrite(bool overwrite) {
+        public LuaCopyTask overwrite(bool overwrite)
+        {
             _taskBuilder.With("AlwaysOverwrite", overwrite);
             return this;
         }
 
-        public LuaCopyTask pattern(string pattern) {
+        public LuaCopyTask pattern(string pattern)
+        {
             _taskBuilder.With("CopyFileByPattern", pattern);
             return this;
         }
 
-        public LuaCopyTask recursive(bool recursive) {
+        public LuaCopyTask recursive(bool recursive)
+        {
             _taskBuilder.With("CopySubfolders", recursive);
             return this;
         }

--- a/eawx-build/Configuration/Lua/v1/LuaCreateSteamWorkshopItemTask.cs
+++ b/eawx-build/Configuration/Lua/v1/LuaCreateSteamWorkshopItemTask.cs
@@ -1,11 +1,15 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using EawXBuild.Core;
 using NLua;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public class LuaCreateSteamWorkshopItemTask : ILuaTask {
-        public LuaCreateSteamWorkshopItemTask(ITaskBuilder taskBuilder, LuaTable table) {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public class LuaCreateSteamWorkshopItemTask : ILuaTask
+    {
+        public LuaCreateSteamWorkshopItemTask(ITaskBuilder taskBuilder, LuaTable table)
+        {
             taskBuilder
                 .With("AppId", Convert.ToUInt32(table["app_id"]))
                 .With("Title", table["title"])
@@ -14,14 +18,14 @@ namespace EawXBuild.Configuration.Lua.v1 {
                 .With("Visibility", table["visibility"])
                 .With("Language", table["language"]);
 
-            var tags = (LuaTable) table["tags"];
-            var stringTags = tags?.Values.Cast<string>().ToHashSet();
+            LuaTable tags = (LuaTable) table["tags"];
+            HashSet<string> stringTags = tags?.Values.Cast<string>().ToHashSet();
             if (stringTags != null)
                 taskBuilder.With("Tags", stringTags);
 
             Task = taskBuilder.Build();
         }
 
-        public ITask Task { get; private set; }
+        public ITask Task { get; }
     }
 }

--- a/eawx-build/Configuration/Lua/v1/LuaJob.cs
+++ b/eawx-build/Configuration/Lua/v1/LuaJob.cs
@@ -2,20 +2,26 @@ using EawXBuild.Core;
 using NLua;
 using NLua.Exceptions;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public class LuaJob {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public class LuaJob
+    {
         private readonly IJob _job;
 
-        public LuaJob(IJob job) {
+        public LuaJob(IJob job)
+        {
             _job = job;
         }
 
-        public void add_task(ILuaTask task) {
+        public void add_task(ILuaTask task)
+        {
             _job.AddTask(task.Task);
         }
 
-        public void add_tasks(LuaTable taskTable) {
-            foreach (var key in taskTable.Keys) {
+        public void add_tasks(LuaTable taskTable)
+        {
+            foreach (object? key in taskTable.Keys)
+            {
                 if (!(taskTable[key] is ILuaTask luaTask))
                     throw new LuaScriptException("Table values must be tasks!", "");
                 _job.AddTask(luaTask.Task);

--- a/eawx-build/Configuration/Lua/v1/LuaProject.cs
+++ b/eawx-build/Configuration/Lua/v1/LuaProject.cs
@@ -1,21 +1,25 @@
 using EawXBuild.Core;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public class LuaProject {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public class LuaProject
+    {
         private readonly IBuildComponentFactory _factory;
 
-        public LuaProject(string name, IBuildComponentFactory factory) {
+        public LuaProject(string name, IBuildComponentFactory factory)
+        {
             _factory = factory;
             Project = factory.MakeProject();
             Project.Name = name;
         }
 
-        public LuaJob add_job(string jobName) {
-            var job = _factory.MakeJob(jobName);
+        public IProject Project { get; }
+
+        public LuaJob add_job(string jobName)
+        {
+            IJob job = _factory.MakeJob(jobName);
             Project.AddJob(job);
             return new LuaJob(job);
         }
-
-        public IProject Project { get; private set; }
     }
 }

--- a/eawx-build/Configuration/Lua/v1/LuaRunProcessTask.cs
+++ b/eawx-build/Configuration/Lua/v1/LuaRunProcessTask.cs
@@ -1,29 +1,35 @@
 using EawXBuild.Core;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public class LuaRunProcessTask : ILuaTask {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public class LuaRunProcessTask : ILuaTask
+    {
         private readonly ITaskBuilder _taskBuilder;
 
-        public LuaRunProcessTask(ITaskBuilder taskBuilder, string path) {
+        public LuaRunProcessTask(ITaskBuilder taskBuilder, string path)
+        {
             _taskBuilder = taskBuilder;
             _taskBuilder.With("ExecutablePath", path);
         }
 
-        public LuaRunProcessTask arguments(string args) {
+        public ITask Task => _taskBuilder.Build();
+
+        public LuaRunProcessTask arguments(string args)
+        {
             _taskBuilder.With("Arguments", args);
             return this;
         }
 
-        public LuaRunProcessTask working_directory(string workingDirectory) {
+        public LuaRunProcessTask working_directory(string workingDirectory)
+        {
             _taskBuilder.With("WorkingDirectory", workingDirectory);
             return this;
         }
 
-        public LuaRunProcessTask allowed_to_fail(bool allowedToFail) {
+        public LuaRunProcessTask allowed_to_fail(bool allowedToFail)
+        {
             _taskBuilder.With("AllowedToFail", allowedToFail);
             return this;
         }
-
-        public ITask Task => _taskBuilder.Build();
     }
 }

--- a/eawx-build/Configuration/Lua/v1/LuaUpdateSteamWorkshopItemTask.cs
+++ b/eawx-build/Configuration/Lua/v1/LuaUpdateSteamWorkshopItemTask.cs
@@ -1,11 +1,15 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using EawXBuild.Core;
 using NLua;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public class LuaUpdateSteamWorkshopItemTask : ILuaTask {
-        public LuaUpdateSteamWorkshopItemTask(ITaskBuilder taskBuilder, LuaTable table) {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public class LuaUpdateSteamWorkshopItemTask : ILuaTask
+    {
+        public LuaUpdateSteamWorkshopItemTask(ITaskBuilder taskBuilder, LuaTable table)
+        {
             taskBuilder
                 .With("AppId", Convert.ToUInt32(table["app_id"]))
                 .With("ItemId", Convert.ToUInt64(table["item_id"]))
@@ -15,8 +19,8 @@ namespace EawXBuild.Configuration.Lua.v1 {
                 .With("Visibility", table["visibility"])
                 .With("Language", table["language"]);
 
-            var tags = (LuaTable) table["tags"];
-            var stringTags = tags?.Values.Cast<string>().ToHashSet();
+            LuaTable tags = (LuaTable) table["tags"];
+            HashSet<string> stringTags = tags?.Values.Cast<string>().ToHashSet();
             if (stringTags != null)
                 taskBuilder.With("Tags", stringTags);
 

--- a/eawx-build/Configuration/Lua/v1/NLuaParser.cs
+++ b/eawx-build/Configuration/Lua/v1/NLuaParser.cs
@@ -1,23 +1,29 @@
 using NLua;
 
-namespace EawXBuild.Configuration.Lua.v1 {
-    public class NLuaParser : ILuaParser {
+namespace EawXBuild.Configuration.Lua.v1
+{
+    public class NLuaParser : ILuaParser
+    {
         private readonly NLua.Lua _lua = new NLua.Lua();
 
-        public LuaTable NewTable(string fullPath) {
+        public LuaTable NewTable(string fullPath)
+        {
             _lua.NewTable(fullPath);
             return _lua.GetTable(fullPath);
         }
 
-        public void RegisterObject(object obj) {
+        public void RegisterObject(object obj)
+        {
             LuaRegistrationHelper.TaggedInstanceMethods(_lua, obj);
         }
 
-        public void DoFile(string fileName) {
+        public void DoFile(string fileName)
+        {
             _lua.DoFile(fileName);
         }
 
-        public void Dispose() {
+        public void Dispose()
+        {
             _lua?.Dispose();
         }
     }

--- a/eawx-build/Core/IBuildComponentFactory.cs
+++ b/eawx-build/Core/IBuildComponentFactory.cs
@@ -1,5 +1,7 @@
-namespace EawXBuild.Core {
-    public interface IBuildComponentFactory {
+namespace EawXBuild.Core
+{
+    public interface IBuildComponentFactory
+    {
         IProject MakeProject();
 
         IJob MakeJob(string name);

--- a/eawx-build/Core/IJob.cs
+++ b/eawx-build/Core/IJob.cs
@@ -1,5 +1,7 @@
-namespace EawXBuild.Core {
-    public interface IJob {
+namespace EawXBuild.Core
+{
+    public interface IJob
+    {
         string Name { get; }
 
         void AddTask(ITask task);

--- a/eawx-build/Core/IProject.cs
+++ b/eawx-build/Core/IProject.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
-namespace EawXBuild.Core {
-    public interface IProject {
+namespace EawXBuild.Core
+{
+    public interface IProject
+    {
         string Name { get; set; }
         void AddJob(IJob job);
 
-        System.Threading.Tasks.Task RunJobAsync(string jobName);
-        List<System.Threading.Tasks.Task> RunAllJobsAsync();
+        Task RunJobAsync(string jobName);
+        List<Task> RunAllJobsAsync();
     }
 }

--- a/eawx-build/Core/ITask.cs
+++ b/eawx-build/Core/ITask.cs
@@ -1,5 +1,7 @@
-namespace EawXBuild.Core {
-    public interface ITask {
+namespace EawXBuild.Core
+{
+    public interface ITask
+    {
         string Id { get; set; }
 
         string Name { get; set; }

--- a/eawx-build/Core/ITaskBuilder.cs
+++ b/eawx-build/Core/ITaskBuilder.cs
@@ -1,5 +1,7 @@
-namespace EawXBuild.Core {
-    public interface ITaskBuilder {
+namespace EawXBuild.Core
+{
+    public interface ITaskBuilder
+    {
         ITaskBuilder With(string name, object value);
 
         ITask Build();

--- a/eawx-build/Core/Job.cs
+++ b/eawx-build/Core/Job.cs
@@ -1,21 +1,25 @@
-using System;
 using System.Collections.Generic;
 
-namespace EawXBuild.Core {
-    public class Job : IJob {
+namespace EawXBuild.Core
+{
+    public class Job : IJob
+    {
         private readonly List<ITask> _tasks = new List<ITask>();
 
-        public Job(string name) {
+        public Job(string name)
+        {
             Name = name;
         }
 
         public string Name { get; }
 
-        public void Run() {
-            foreach (var task in _tasks) task.Run();
+        public void Run()
+        {
+            foreach (ITask task in _tasks) task.Run();
         }
 
-        public void AddTask(ITask task) {
+        public void AddTask(ITask task)
+        {
             _tasks.Add(task);
         }
     }

--- a/eawx-build/Core/Project.cs
+++ b/eawx-build/Core/Project.cs
@@ -3,36 +3,43 @@ using System.Linq;
 using System.Threading.Tasks;
 using EawXBuild.Exceptions;
 
-namespace EawXBuild.Core {
-    public class Project : IProject {
+namespace EawXBuild.Core
+{
+    public class Project : IProject
+    {
         private readonly List<IJob> jobs = new List<IJob>();
 
         public string Name { get; set; }
 
-        public void AddJob(IJob job) {
+        public void AddJob(IJob job)
+        {
             if (HasJobWithName(job.Name))
                 throw new DuplicateJobNameException(job.Name);
 
             jobs.Add(job);
         }
 
-        public Task RunJobAsync(string jobName) {
-            var job = FindJobWithName(jobName);
+        public Task RunJobAsync(string jobName)
+        {
+            IJob job = FindJobWithName(jobName);
             if (job == null)
                 throw new JobNotFoundException(jobName);
 
             return Task.Run(() => job.Run());
         }
 
-        public List<Task> RunAllJobsAsync() {
+        public List<Task> RunAllJobsAsync()
+        {
             return jobs.Select(job => Task.Run(job.Run)).ToList();
         }
 
-        private IJob FindJobWithName(string jobName) {
+        private IJob FindJobWithName(string jobName)
+        {
             return jobs.Find(job => job.Name.Equals(jobName));
         }
 
-        private bool HasJobWithName(string jobName) {
+        private bool HasJobWithName(string jobName)
+        {
             return jobs.Exists(j => j.Name.Equals(jobName));
         }
     }

--- a/eawx-build/EawXBuildApplication.cs
+++ b/eawx-build/EawXBuildApplication.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO.Abstractions;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using EawXBuild.Configuration.CLI;
@@ -12,32 +12,40 @@ using EawXBuild.Environment;
 using EawXBuild.Services.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
-namespace EawXBuild {
-    internal class EawXBuildApplication {
+namespace EawXBuild
+{
+    internal class EawXBuildApplication
+    {
         public IServiceProvider Services { get; }
-        private readonly ILogger<EawXBuildApplication> _logger;
+        [NotNull] private readonly ILogger<EawXBuildApplication> _logger;
 
         private IOptions Opts { get; }
 
-        public EawXBuildApplication(IServiceProvider services, IOptions opts) {
+        public EawXBuildApplication(IServiceProvider services, IOptions opts)
+        {
             Services = services;
             Opts = opts;
-            _logger = Services.GetRequiredService<ILoggerFactory>()?.CreateLogger<EawXBuildApplication>();
-            _logger?.LogTrace("Application initialised successfully.");
+            ILoggerFactory loggerFactory = Services.GetRequiredService<ILoggerFactory>() ?? new NullLoggerFactory();
+            _logger = loggerFactory.CreateLogger<EawXBuildApplication>();
+            _logger.LogTrace("Application initialised successfully");
         }
 
-        internal ExitCode Run() {
-            return Opts switch {
+        internal ExitCode Run()
+        {
+            return Opts switch
+            {
                 RunOptions runOptions => RunInternal(runOptions),
                 ValidateOptions validateOptions => RunValidateInternal(validateOptions),
                 _ => ExitCode.ExUsage
             };
         }
 
-        private ExitCode RunInternal(RunOptions runOptions) {
-            _logger?.LogInformation("Running application in RUN mode.");
-            var ioService = Services.GetService<IIOService>();
+        private ExitCode RunInternal(RunOptions runOptions)
+        {
+            _logger.LogInformation("Running application in RUN mode");
+            var ioService = Services.GetService<IIOHelperService>();
             IBuildConfigParser buildConfigParser = null;
             if (runOptions.BackendLua)
                 buildConfigParser = GetLuaBuildConfigParserInternal();
@@ -55,27 +63,31 @@ namespace EawXBuild {
                 : ExecRunInternal(runOptions, buildConfigParser, path);
         }
 
-        private static bool TryExtractAndValidatePathInternal(IIOService ioService, string pathIn, string fileExtension,
-            out string pathOut, out ExitCode exitCode) {
-            var currentDirectory = ioService.FileSystem.Directory.GetCurrentDirectory();
-            if (!ioService.IsValidPath(pathIn, currentDirectory, fileExtension)) {
+        private static bool TryExtractAndValidatePathInternal(IIOHelperService iioHelperService, string pathIn, string fileExtension,
+            out string pathOut, out ExitCode exitCode)
+        {
+            var currentDirectory = iioHelperService.FileSystem.Directory.GetCurrentDirectory();
+            if (!iioHelperService.IsValidPath(pathIn, currentDirectory, fileExtension))
+            {
                 pathOut = null;
-                exitCode = ioService.ValidatePath(pathIn, currentDirectory, fileExtension);
+                exitCode = iioHelperService.ValidatePath(pathIn, currentDirectory, fileExtension);
                 return false;
             }
 
-            pathOut = ioService.ResolvePath(pathIn, currentDirectory, fileExtension);
+            pathOut = iioHelperService.ResolvePath(pathIn, currentDirectory, fileExtension);
             exitCode = ExitCode.Success;
             return true;
         }
 
-        private ExitCode ExecRunInternal(RunOptions runOptions, IBuildConfigParser buildConfigParser, string path) {
+        private ExitCode ExecRunInternal(RunOptions runOptions, IBuildConfigParser buildConfigParser, string path)
+        {
             var projects = buildConfigParser.Parse(path);
             var project = projects.FirstOrDefault(p =>
                 p.Name.Equals(runOptions.ProjectName, StringComparison.CurrentCulture));
 
-            if (project == null) {
-                _logger?.LogError($"No project found for name \"{runOptions.ProjectName}\".");
+            if (project == null)
+            {
+                _logger.LogError("No project found for name \"{0}\"", runOptions.ProjectName);
                 return ExitCode.ExUsage;
             }
 
@@ -83,86 +95,104 @@ namespace EawXBuild {
 
             Task.WaitAll(tasks.ToArray());
             var errCount = 0;
-            foreach (var task in tasks.Where(task => null != task.Exception)) {
+            foreach (var task in tasks.Where(task => null != task.Exception))
+            {
                 errCount += 1;
-                _logger?.LogError($"An error occured running the job {project.Name}.{runOptions.JobName}: ",
-                    task.Exception);
+                _logger.LogError(task.Exception, "An error occured running the job {0}.{1}", project.Name,
+                    runOptions.JobName);
             }
 
-            if (errCount == 0) {
-                _logger?.LogInformation($"{project.Name} ran {tasks.Count} tasks successfully.");
+            if (errCount == 0)
+            {
+                _logger.LogInformation($"{project.Name} ran {tasks.Count} tasks successfully.");
                 return ExitCode.Success;
             }
 
-            if (errCount == tasks.Count) {
-                _logger?.LogInformation($"{project.Name} could not be run. All tasks failed.");
+            if (errCount == tasks.Count)
+            {
+                _logger.LogInformation($"{project.Name} could not be run. All tasks failed.");
                 return ExitCode.RunFailed;
             }
 
-            _logger?.LogInformation(
+            _logger.LogInformation(
                 $"{project.Name} could not complete: {errCount} of {tasks.Count} tasks failed.");
             return ExitCode.MultipleJobsFailed;
         }
 
-        private List<Task> RunMatchingTasks(RunOptions runOptions, IProject project) {
+        private List<Task> RunMatchingTasks(RunOptions runOptions, IProject project)
+        {
             var tasks = new List<Task>();
-            if (string.IsNullOrEmpty(runOptions.JobName) || string.IsNullOrWhiteSpace(runOptions.JobName)) {
-                try {
+            if (string.IsNullOrEmpty(runOptions.JobName) || string.IsNullOrWhiteSpace(runOptions.JobName))
+            {
+                try
+                {
                     tasks.AddRange(project.RunAllJobsAsync());
                 }
-                catch (Exception e) {
-                    _logger?.LogError($"An error occured running all tasks for {project.Name}: ", e);
+                catch (Exception e)
+                {
+                    _logger.LogError($"An error occured running all tasks for {project.Name}: ", e);
                 }
             }
-            else {
-                try {
+            else
+            {
+                try
+                {
                     tasks.Add(project.RunJobAsync(runOptions.JobName));
                 }
-                catch (Exception e) {
-                    _logger?.LogError($"An error occured running the job {project.Name}.{runOptions.JobName}: ", e);
+                catch (Exception e)
+                {
+                    _logger.LogError($"An error occured running the job {project.Name}.{runOptions.JobName}: ", e);
                 }
             }
 
             return tasks;
         }
 
-        internal IBuildConfigParser GetXmlBuildConfigParserInternal(IIOService ioService) {
-            _logger?.LogInformation("Running application with XML backend.");
-            return new XmlBuildConfigParser(ioService.FileSystem,
+        internal IBuildConfigParser GetXmlBuildConfigParserInternal(IIOHelperService iioHelperService)
+        {
+            _logger.LogInformation("Running application with XML backend.");
+            return new XmlBuildConfigParser(iioHelperService.FileSystem,
                 Services.GetService<IBuildComponentFactory>(),
                 Services.GetRequiredService<ILoggerFactory>());
         }
 
-        internal IBuildConfigParser GetLuaBuildConfigParserInternal() {
-            _logger?.LogInformation("Running application LUA backend.");
+        internal IBuildConfigParser GetLuaBuildConfigParserInternal()
+        {
+            _logger.LogInformation("Running application LUA backend.");
             return new LuaBuildConfigParser(
                 Services.GetService<ILuaParser>(), Services.GetService<IBuildComponentFactory>());
         }
 
-        private ExitCode RunValidateInternal(IOptions validateOptions) {
-            _logger?.LogInformation("Running application in VALIDATION mode.");
-            var ioService = Services.GetService<IIOService>();
+        private ExitCode RunValidateInternal(IOptions validateOptions)
+        {
+            _logger.LogInformation("Running application in VALIDATION mode.");
+            var ioService = Services.GetService<IIOHelperService>();
             string fileExtension = null;
             IBuildConfigParser buildConfigParser = null;
 
-            if (validateOptions.BackendLua) {
+            if (validateOptions.BackendLua)
+            {
                 fileExtension = ".lua";
                 buildConfigParser = GetLuaBuildConfigParserInternal();
             }
-            else {
-                if (validateOptions.BackendXml) {
+            else
+            {
+                if (validateOptions.BackendXml)
+                {
                     fileExtension = ".xml";
                     buildConfigParser = GetXmlBuildConfigParserInternal(ioService);
                 }
             }
 
-            if (string.IsNullOrWhiteSpace(fileExtension) || null == buildConfigParser) {
+            if (string.IsNullOrWhiteSpace(fileExtension) || null == buildConfigParser)
+            {
                 return ExitCode.ExUsage;
             }
 
             if (!TryExtractAndValidatePathInternal(ioService, validateOptions.ConfigPath, fileExtension,
                 out string path,
-                out ExitCode exitCode)) {
+                out ExitCode exitCode))
+            {
                 return exitCode;
             }
 

--- a/eawx-build/Environment/ExitCode.cs
+++ b/eawx-build/Environment/ExitCode.cs
@@ -1,21 +1,23 @@
-namespace EawXBuild.Environment {
-    /**
+namespace EawXBuild.Environment
+{
+ /**
      * Standard exit codes used within bash and C/C++
      * Sources:
      * <list type="bullet">
-     *   <item>
-     *     <description>
-     *       https://tldp.org/LDP/abs/html/exitcodes.html
-     *     </description>
-     *   </item>
-     *   <item>
-     *     <description>
-     *       https://www.apt-browse.org/browse/ubuntu/trusty/main/amd64/libc6-dev/2.19-0ubuntu6/file/usr/include/sysexits.h
-     *     </description>
-     *   </item>
+     *     <item>
+     *         <description>
+     *             https://tldp.org/LDP/abs/html/exitcodes.html
+     *         </description>
+     *     </item>
+     *     <item>
+     *         <description>
+     *             https://www.apt-browse.org/browse/ubuntu/trusty/main/amd64/libc6-dev/2.19-0ubuntu6/file/usr/include/sysexits.h
+     *         </description>
+     *     </item>
      * </list>
      */
-    public enum ExitCode {
+ public enum ExitCode
+    {
         /**
          * The program ran successfully.
          */

--- a/eawx-build/Exceptions/DuplicateJobNameException.cs
+++ b/eawx-build/Exceptions/DuplicateJobNameException.cs
@@ -1,8 +1,12 @@
 using System;
 
-namespace EawXBuild.Exceptions {
+namespace EawXBuild.Exceptions
+{
     [Serializable]
-    public class DuplicateJobNameException : Exception {
-        public DuplicateJobNameException(string jobName) : base($"Duplicate Job {jobName}") { }
+    public class DuplicateJobNameException : Exception
+    {
+        public DuplicateJobNameException(string jobName) : base($"Duplicate Job {jobName}")
+        {
+        }
     }
 }

--- a/eawx-build/Exceptions/JobNotFoundException.cs
+++ b/eawx-build/Exceptions/JobNotFoundException.cs
@@ -1,8 +1,12 @@
 using System;
 
-namespace EawXBuild.Exceptions {
+namespace EawXBuild.Exceptions
+{
     [Serializable]
-    public class JobNotFoundException : Exception {
-        public JobNotFoundException(string jobName) : base($"No Job with name {jobName}") { }
+    public class JobNotFoundException : Exception
+    {
+        public JobNotFoundException(string jobName) : base($"No Job with name {jobName}")
+        {
+        }
     }
 }

--- a/eawx-build/Exceptions/NoRelativePathException.cs
+++ b/eawx-build/Exceptions/NoRelativePathException.cs
@@ -1,8 +1,12 @@
 using System;
 
-namespace EawXBuild.Exceptions {
+namespace EawXBuild.Exceptions
+{
     [Serializable]
-    public class NoRelativePathException : Exception {
-        public NoRelativePathException(string path) : base($"Path {path} is not a relative path") { }
+    public class NoRelativePathException : Exception
+    {
+        public NoRelativePathException(string path) : base($"Path {path} is not a relative path")
+        {
+        }
     }
 }

--- a/eawx-build/Exceptions/NoSuchFileSystemObjectException.cs
+++ b/eawx-build/Exceptions/NoSuchFileSystemObjectException.cs
@@ -1,9 +1,13 @@
 using System;
 
-namespace EawXBuild.Exceptions {
+namespace EawXBuild.Exceptions
+{
     [Serializable]
-    public class NoSuchFileSystemObjectException : Exception {
+    public class NoSuchFileSystemObjectException : Exception
+    {
         public NoSuchFileSystemObjectException(string fileSystemObjectName) : base(
-            $"No such file or directory: {fileSystemObjectName}") { }
+            $"No such file or directory: {fileSystemObjectName}")
+        {
+        }
     }
 }

--- a/eawx-build/Exceptions/ProcessFailedException.cs
+++ b/eawx-build/Exceptions/ProcessFailedException.cs
@@ -1,7 +1,11 @@
 using System;
 
-namespace EawXBuild.Exceptions {
-    public class ProcessFailedException : Exception {
-        public ProcessFailedException(string message = null) : base(message) { }
+namespace EawXBuild.Exceptions
+{
+    public class ProcessFailedException : Exception
+    {
+        public ProcessFailedException(string message = null) : base(message)
+        {
+        }
     }
 }

--- a/eawx-build/Host.cs
+++ b/eawx-build/Host.cs
@@ -13,36 +13,43 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Logging.Debug;
 
-namespace EawXBuild {
-    internal class Host {
-        private static void Main(string[] args) {
+namespace EawXBuild
+{
+    internal class Host
+    {
+        private static void Main(string[] args)
+        {
             Parser.Default.ParseArguments<RunOptions, ValidateOptions>(args)
                 .WithParsed<RunOptions>(ExecInternal)
                 .WithParsed<ValidateOptions>(ExecInternal)
                 .WithNotParsed(HandleParseErrorsInternal);
         }
 
-        private static void ExecInternal(IOptions opts) {
-            var serviceCollection = new ServiceCollection();
+        private static void ExecInternal(IOptions opts)
+        {
+            ServiceCollection serviceCollection = new ServiceCollection();
             ConfigureServices(serviceCollection, opts.Verbose);
-            var application = new EawXBuildApplication(serviceCollection.BuildServiceProvider(), opts);
+            EawXBuildApplication application = new EawXBuildApplication(serviceCollection.BuildServiceProvider(), opts);
             System.Environment.ExitCode = (int) application.Run();
         }
 
-        private static void ConfigureServices(IServiceCollection serviceCollection, bool verbose) {
-            serviceCollection.AddLogging(config => {
+        private static void ConfigureServices(IServiceCollection serviceCollection, bool verbose)
+        {
+            serviceCollection.AddLogging(config =>
+                {
 #if DEBUG
                     config.AddDebug();
 #endif
                     config.AddConsole();
                 })
-                .Configure<LoggerFilterOptions>(options => {
+                .Configure<LoggerFilterOptions>(options =>
+                {
 #if DEBUG
                     options.AddFilter<DebugLoggerProvider>(null, LogLevel.Trace);
 #endif
                     options.AddFilter<ConsoleLoggerProvider>(null, verbose ? LogLevel.Trace : LogLevel.Warning);
                 });
-            var serviceProvider = serviceCollection.BuildServiceProvider();
+            ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
             serviceCollection.AddTransient<IIOHelperService, IOHelperService>(s =>
                 new IOHelperService(new FileSystem(), serviceProvider.GetRequiredService<ILoggerFactory>()));
             serviceCollection.AddTransient<IBuildComponentFactory, BuildComponentFactory>(s =>
@@ -51,9 +58,11 @@ namespace EawXBuild {
             serviceCollection.AddTransient<ILuaParser, NLuaParser>(s => new NLuaParser());
         }
 
-        private static void HandleParseErrorsInternal(IEnumerable<Error> errs) {
+        private static void HandleParseErrorsInternal(IEnumerable<Error> errs)
+        {
             IEnumerable<Error> errors = errs as Error[] ?? errs.ToArray();
-            if (errors.OfType<HelpVerbRequestedError>().Any() || errors.OfType<HelpRequestedError>().Any()) {
+            if (errors.OfType<HelpVerbRequestedError>().Any() || errors.OfType<HelpRequestedError>().Any())
+            {
                 System.Environment.ExitCode = (int) ExitCode.Success;
                 return;
             }

--- a/eawx-build/Host.cs
+++ b/eawx-build/Host.cs
@@ -43,8 +43,8 @@ namespace EawXBuild {
                     options.AddFilter<ConsoleLoggerProvider>(null, verbose ? LogLevel.Trace : LogLevel.Warning);
                 });
             var serviceProvider = serviceCollection.BuildServiceProvider();
-            serviceCollection.AddTransient<IIOService, IOService>(s =>
-                new IOService(new FileSystem(), serviceProvider.GetRequiredService<ILoggerFactory>()));
+            serviceCollection.AddTransient<IIOHelperService, IOHelperService>(s =>
+                new IOHelperService(new FileSystem(), serviceProvider.GetRequiredService<ILoggerFactory>()));
             serviceCollection.AddTransient<IBuildComponentFactory, BuildComponentFactory>(s =>
                 new BuildComponentFactory(
                     serviceProvider.GetRequiredService<ILoggerFactory>().CreateLogger<BuildComponentFactory>()));

--- a/eawx-build/Host.cs
+++ b/eawx-build/Host.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using System.Linq;
 using CommandLine;
@@ -15,6 +16,7 @@ using Microsoft.Extensions.Logging.Debug;
 
 namespace EawXBuild
 {
+    [ExcludeFromCodeCoverage]
     internal class Host
     {
         private static void Main(string[] args)

--- a/eawx-build/Native/FileLinkerFactory.cs
+++ b/eawx-build/Native/FileLinkerFactory.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace EawXBuild.Native {
-    public class FileLinkerFactory : IFileLinkerFactory {
-        public IFileLinker MakeFileLinker() {
+namespace EawXBuild.Native
+{
+    public class FileLinkerFactory : IFileLinkerFactory
+    {
+        public IFileLinker MakeFileLinker()
+        {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 return new MacOSFileLinker();
 

--- a/eawx-build/Native/IFileLinker.cs
+++ b/eawx-build/Native/IFileLinker.cs
@@ -1,5 +1,7 @@
-namespace EawXBuild.Native {
-    public interface IFileLinker {
+namespace EawXBuild.Native
+{
+    public interface IFileLinker
+    {
         void CreateLink(string source, string target);
     }
 }

--- a/eawx-build/Native/IFileLinkerFactory.cs
+++ b/eawx-build/Native/IFileLinkerFactory.cs
@@ -1,5 +1,7 @@
-namespace EawXBuild.Native {
-    public interface IFileLinkerFactory {
+namespace EawXBuild.Native
+{
+    public interface IFileLinkerFactory
+    {
         IFileLinker MakeFileLinker();
     }
 }

--- a/eawx-build/Native/LinuxFileLinker.cs
+++ b/eawx-build/Native/LinuxFileLinker.cs
@@ -1,11 +1,14 @@
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace EawXBuild.Native {
-    public class LinuxFileLinker : IFileLinker {
-        public void CreateLink(string source, string target) {
-            var platformSourcePath = source.Replace("\\", "/");
-            var platformTargetPath = target.Replace("\\", "/");
+namespace EawXBuild.Native
+{
+    public class LinuxFileLinker : IFileLinker
+    {
+        public void CreateLink(string source, string target)
+        {
+            string platformSourcePath = source.Replace("\\", "/");
+            string platformTargetPath = target.Replace("\\", "/");
             byte[] sourceBytes = Encoding.UTF8.GetBytes(platformSourcePath);
             byte[] targetBytes = Encoding.UTF8.GetBytes(platformTargetPath);
             link(sourceBytes, targetBytes);

--- a/eawx-build/Native/MacOSFileLinker.cs
+++ b/eawx-build/Native/MacOSFileLinker.cs
@@ -1,14 +1,16 @@
-using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace EawXBuild.Native {
-    public class MacOSFileLinker : IFileLinker {
-        public void CreateLink(string source, string target) {
-            var platformSourcePath = source.Replace("\\", "/");
-            var platformTargetPath = target.Replace("\\", "/");
-            var sourceBytes = Encoding.UTF8.GetBytes(platformSourcePath);
-            var targetBytes = Encoding.UTF8.GetBytes(platformTargetPath);
+namespace EawXBuild.Native
+{
+    public class MacOSFileLinker : IFileLinker
+    {
+        public void CreateLink(string source, string target)
+        {
+            string platformSourcePath = source.Replace("\\", "/");
+            string platformTargetPath = target.Replace("\\", "/");
+            byte[] sourceBytes = Encoding.UTF8.GetBytes(platformSourcePath);
+            byte[] targetBytes = Encoding.UTF8.GetBytes(platformTargetPath);
             link(sourceBytes, targetBytes);
         }
 

--- a/eawx-build/Native/WinFileLinker.cs
+++ b/eawx-build/Native/WinFileLinker.cs
@@ -1,20 +1,22 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace EawXBuild.Native {
-    public class WinFileLinker : IFileLinker {
+namespace EawXBuild.Native
+{
+    public class WinFileLinker : IFileLinker
+    {
+        public void CreateLink(string source, string target)
+        {
+            string platformSpecificSourcePath = source.Replace("/", "\\");
+            string platformSpecificTargetPath = target.Replace("/", "\\");
+            CreateHardLink(platformSpecificTargetPath, platformSpecificSourcePath, IntPtr.Zero);
+        }
+
         [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
         private static extern bool CreateHardLink(
             string lpFileName,
             string lpExistingFileName,
             IntPtr lpSecurityAttributes
         );
-
-
-        public void CreateLink(string source, string target) {
-            var platformSpecificSourcePath = source.Replace("/", "\\");
-            var platformSpecificTargetPath = target.Replace("/", "\\");
-            CreateHardLink(platformSpecificTargetPath, platformSpecificSourcePath, IntPtr.Zero);
-        }
     }
 }

--- a/eawx-build/Services/IO/IIOHelperService.cs
+++ b/eawx-build/Services/IO/IIOHelperService.cs
@@ -2,7 +2,7 @@ using System.IO.Abstractions;
 using EawXBuild.Environment;
 
 namespace EawXBuild.Services.IO {
-    internal interface IIOService {
+    internal interface IIOHelperService {
         ExitCode ValidatePath(string path, string relativePath = "", string fileExtension = "");
         string ResolvePath(string path, string relativePath = "", string fileExtension = "");
         bool IsValidPath(string path, string relativePath = "", string fileExtension = "");

--- a/eawx-build/Services/IO/IIOHelperService.cs
+++ b/eawx-build/Services/IO/IIOHelperService.cs
@@ -1,11 +1,13 @@
 using System.IO.Abstractions;
 using EawXBuild.Environment;
 
-namespace EawXBuild.Services.IO {
-    internal interface IIOHelperService {
+namespace EawXBuild.Services.IO
+{
+    internal interface IIOHelperService
+    {
+        IFileSystem FileSystem { get; }
         ExitCode ValidatePath(string path, string relativePath = "", string fileExtension = "");
         string ResolvePath(string path, string relativePath = "", string fileExtension = "");
         bool IsValidPath(string path, string relativePath = "", string fileExtension = "");
-        IFileSystem FileSystem { get; }
     }
 }

--- a/eawx-build/Services/IO/IOHelperService.cs
+++ b/eawx-build/Services/IO/IOHelperService.cs
@@ -9,8 +9,6 @@ using EawXBuild.Environment;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-[assembly: InternalsVisibleTo("eawx-build-test")]
-
 namespace EawXBuild.Services.IO
 {
     internal class IOHelperService : IIOHelperService
@@ -27,6 +25,7 @@ namespace EawXBuild.Services.IO
 
         [NotNull] public IFileSystem FileSystem { get; }
 
+        [ExcludeFromCodeCoverage]
         public ExitCode ValidatePath([NotNull] string path, [NotNull] string relativePath = "",
             [NotNull] string fileExtension = "")
         {

--- a/eawx-build/Services/IO/IOHelperService.cs
+++ b/eawx-build/Services/IO/IOHelperService.cs
@@ -6,71 +6,89 @@ using System.IO.Abstractions;
 using System.Runtime.CompilerServices;
 using EawXBuild.Environment;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 [assembly: InternalsVisibleTo("eawx-build-test")]
 
-namespace EawXBuild.Services.IO {
-    internal class IOService : IIOService {
-        private readonly ILogger<IOService> _logger;
+namespace EawXBuild.Services.IO
+{
+    internal class IOHelperService : IIOHelperService
+    {
+        private readonly ILogger<IOHelperService> _logger;
         [NotNull] public IFileSystem FileSystem { get; }
 
-        public IOService(IFileSystem fileSystem, ILoggerFactory loggerFactory = null) {
-            _logger = loggerFactory?.CreateLogger<IOService>();
+        public IOHelperService(IFileSystem fileSystem, ILoggerFactory loggerFactory = null)
+        {
+            ILoggerFactory lf = loggerFactory ?? new NullLoggerFactory();
+            _logger = lf.CreateLogger<IOHelperService>();
             FileSystem = fileSystem ?? new FileSystem();
-            _logger?.LogTrace($"{nameof(IOService)} initialised successfully.");
+            _logger.LogTrace("{0} initialised successfully.", nameof(IOHelperService));
         }
 
         public ExitCode ValidatePath([NotNull] string path, [NotNull] string relativePath = "",
-            [NotNull] string fileExtension = "") {
+            [NotNull] string fileExtension = "")
+        {
             Debug.Assert(path != null, nameof(path) + " != null");
-            if (path.IndexOfAny(FileSystem.Path.GetInvalidPathChars()) == -1) {
-                try {
+            if (path.IndexOfAny(FileSystem.Path.GetInvalidPathChars()) == -1)
+            {
+                try
+                {
                     ResolvePath(path, relativePath, fileExtension);
                     return ExitCode.Success;
                 }
-                catch (ArgumentNullException e) {
-                    _logger?.LogError($"{e}");
+                catch (ArgumentNullException e)
+                {
+                    _logger.LogError(e, "An error occurred");
                     return ExitCode.ExUsage;
                 }
-                catch (System.Security.SecurityException e) {
-                    _logger?.LogError($"{e}");
+                catch (System.Security.SecurityException e)
+                {
+                    _logger.LogError(e, "An error occurred");
                     return ExitCode.ExNoperm;
                 }
-                catch (ArgumentException e) {
-                    _logger?.LogError($"{e}");
+                catch (ArgumentException e)
+                {
+                    _logger.LogError(e, "An error occurred");
                     return ExitCode.ExUsage;
                 }
-                catch (UnauthorizedAccessException e) {
-                    _logger?.LogError($"{e}");
+                catch (UnauthorizedAccessException e)
+                {
+                    _logger.LogError(e, "An error occurred");
                     return ExitCode.ExNoperm;
                 }
-                catch (PathTooLongException e) {
-                    _logger?.LogError($"{e}");
+                catch (PathTooLongException e)
+                {
+                    _logger.LogError(e, "An error occurred");
                     return ExitCode.ExOserr;
                 }
-                catch (NotSupportedException e) {
-                    _logger?.LogError($"{e}");
+                catch (NotSupportedException e)
+                {
+                    _logger.LogError(e, "An error occurred");
                     return ExitCode.ExOserr;
                 }
-                catch (FileNotFoundException e) {
-                    _logger?.LogError($"{e}");
+                catch (FileNotFoundException e)
+                {
+                    _logger.LogError(e, "An error occurred");
                     return ExitCode.ExIoerr;
                 }
-                catch (IOException e) {
-                    _logger?.LogError($"{e}");
+                catch (IOException e)
+                {
+                    _logger.LogError(e, "An error occurred");
                     return ExitCode.ExIoerr;
                 }
-                catch (Exception e) {
-                    _logger?.LogError($"{e}");
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "An error occurred");
                     return ExitCode.GenericError;
                 }
             }
 
-            _logger?.LogError($"The provided path {path} contains unsupported characters.");
+            _logger.LogError("The provided path \"{0}\" contains unsupported characters.", path);
             return ExitCode.ExOserr;
         }
 
-        public string ResolvePath(string path, string relativePath = "", string fileExtension = "") {
+        public string ResolvePath(string path, string relativePath = "", string fileExtension = "")
+        {
             var fullyQualifiedPath = GetFullyQualifiedPath(path, relativePath);
             var fileInfo = FileSystem.FileInfo.FromFileName(fullyQualifiedPath);
             if (!fileInfo.Exists) throw new FileNotFoundException($"The file {path} does not exist");
@@ -82,7 +100,8 @@ namespace EawXBuild.Services.IO {
             return fullyQualifiedPath;
         }
 
-        private string GetFullyQualifiedPath(string path, string relativePath) {
+        private string GetFullyQualifiedPath(string path, string relativePath)
+        {
             if (FileSystem.Path.IsPathRooted(path))
                 return FileSystem.Path.GetFullPath(path);
 
@@ -93,13 +112,15 @@ namespace EawXBuild.Services.IO {
             return fullyQualifiedPath;
         }
 
-        private bool FullPathEndsWithExtension(string fullyQualifiedPath, string fileExtension) {
+        private bool FullPathEndsWithExtension(string fullyQualifiedPath, string fileExtension)
+        {
             return FileSystem.Path.GetExtension(fullyQualifiedPath)
                 .Equals(fileExtension, StringComparison.InvariantCultureIgnoreCase);
         }
 
 
-        public bool IsValidPath(string path, string relativePath = "", string fileExtension = "") {
+        public bool IsValidPath(string path, string relativePath = "", string fileExtension = "")
+        {
             return ValidatePath(path, relativePath, fileExtension) == ExitCode.Success;
         }
     }

--- a/eawx-build/Services/IO/IOHelperService.cs
+++ b/eawx-build/Services/IO/IOHelperService.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Abstractions;
 using System.Runtime.CompilerServices;
+using System.Security;
 using EawXBuild.Environment;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -15,7 +16,6 @@ namespace EawXBuild.Services.IO
     internal class IOHelperService : IIOHelperService
     {
         private readonly ILogger<IOHelperService> _logger;
-        [NotNull] public IFileSystem FileSystem { get; }
 
         public IOHelperService(IFileSystem fileSystem, ILoggerFactory loggerFactory = null)
         {
@@ -25,12 +25,13 @@ namespace EawXBuild.Services.IO
             _logger.LogTrace("{0} initialised successfully.", nameof(IOHelperService));
         }
 
+        [NotNull] public IFileSystem FileSystem { get; }
+
         public ExitCode ValidatePath([NotNull] string path, [NotNull] string relativePath = "",
             [NotNull] string fileExtension = "")
         {
             Debug.Assert(path != null, nameof(path) + " != null");
             if (path.IndexOfAny(FileSystem.Path.GetInvalidPathChars()) == -1)
-            {
                 try
                 {
                     ResolvePath(path, relativePath, fileExtension);
@@ -41,7 +42,7 @@ namespace EawXBuild.Services.IO
                     _logger.LogError(e, "An error occurred");
                     return ExitCode.ExUsage;
                 }
-                catch (System.Security.SecurityException e)
+                catch (SecurityException e)
                 {
                     _logger.LogError(e, "An error occurred");
                     return ExitCode.ExNoperm;
@@ -81,7 +82,6 @@ namespace EawXBuild.Services.IO
                     _logger.LogError(e, "An error occurred");
                     return ExitCode.GenericError;
                 }
-            }
 
             _logger.LogError("The provided path \"{0}\" contains unsupported characters.", path);
             return ExitCode.ExOserr;
@@ -89,8 +89,8 @@ namespace EawXBuild.Services.IO
 
         public string ResolvePath(string path, string relativePath = "", string fileExtension = "")
         {
-            var fullyQualifiedPath = GetFullyQualifiedPath(path, relativePath);
-            var fileInfo = FileSystem.FileInfo.FromFileName(fullyQualifiedPath);
+            string fullyQualifiedPath = GetFullyQualifiedPath(path, relativePath);
+            IFileInfo fileInfo = FileSystem.FileInfo.FromFileName(fullyQualifiedPath);
             if (!fileInfo.Exists) throw new FileNotFoundException($"The file {path} does not exist");
             if (string.IsNullOrEmpty(fileExtension)) return fullyQualifiedPath;
             if (!FullPathEndsWithExtension(fullyQualifiedPath, fileExtension))
@@ -100,12 +100,18 @@ namespace EawXBuild.Services.IO
             return fullyQualifiedPath;
         }
 
+
+        public bool IsValidPath(string path, string relativePath = "", string fileExtension = "")
+        {
+            return ValidatePath(path, relativePath, fileExtension) == ExitCode.Success;
+        }
+
         private string GetFullyQualifiedPath(string path, string relativePath)
         {
             if (FileSystem.Path.IsPathRooted(path))
                 return FileSystem.Path.GetFullPath(path);
 
-            var fullyQualifiedPath = string.IsNullOrEmpty(relativePath)
+            string fullyQualifiedPath = string.IsNullOrEmpty(relativePath)
                 ? FileSystem.Path.GetFullPath(relativePath)
                 : FileSystem.Path.GetFullPath(FileSystem.Path.Combine(relativePath, path));
 
@@ -116,12 +122,6 @@ namespace EawXBuild.Services.IO
         {
             return FileSystem.Path.GetExtension(fullyQualifiedPath)
                 .Equals(fileExtension, StringComparison.InvariantCultureIgnoreCase);
-        }
-
-
-        public bool IsValidPath(string path, string relativePath = "", string fileExtension = "")
-        {
-            return ValidatePath(path, relativePath, fileExtension) == ExitCode.Success;
         }
     }
 }

--- a/eawx-build/Services/Process/IProcessRunner.cs
+++ b/eawx-build/Services/Process/IProcessRunner.cs
@@ -1,15 +1,15 @@
-using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace EawXBuild.Services.Process {
-    public interface IProcessRunner {
+namespace EawXBuild.Services.Process
+{
+    public interface IProcessRunner
+    {
+        int ExitCode { get; }
         void Start(string executablePath);
         void Start(string executablePath, string arguments);
 
         void Start(ProcessStartInfo startInfo);
 
         void WaitForExit();
-
-        int ExitCode { get; }
     }
 }

--- a/eawx-build/Services/Process/ProcessRunner.cs
+++ b/eawx-build/Services/Process/ProcessRunner.cs
@@ -1,16 +1,21 @@
 using System;
 using System.Diagnostics;
 
-namespace EawXBuild.Services.Process {
-    public class ProcessRunner : IProcessRunner {
+namespace EawXBuild.Services.Process
+{
+    public class ProcessRunner : IProcessRunner
+    {
         private System.Diagnostics.Process _process;
 
-        public void Start(string executablePath) {
+        public void Start(string executablePath)
+        {
             Start(executablePath, null);
         }
 
-        public void Start(string executablePath, string arguments) {
-            var startInfo = new ProcessStartInfo {
+        public void Start(string executablePath, string arguments)
+        {
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
                 FileName = executablePath,
                 WorkingDirectory = System.Environment.CurrentDirectory,
                 Arguments = arguments
@@ -19,9 +24,11 @@ namespace EawXBuild.Services.Process {
             Start(startInfo);
         }
 
-        public void Start(ProcessStartInfo startInfo) {
+        public void Start(ProcessStartInfo startInfo)
+        {
             RedirectIOForProcessStartInfo(startInfo);
-            _process = new System.Diagnostics.Process {
+            _process = new System.Diagnostics.Process
+            {
                 StartInfo = startInfo
             };
 
@@ -30,17 +37,19 @@ namespace EawXBuild.Services.Process {
         }
 
 
-        public void WaitForExit() {
+        public void WaitForExit()
+        {
             _process.WaitForExit();
         }
 
-        private static void RedirectIOForProcessStartInfo(ProcessStartInfo startInfo) {
+        public int ExitCode => _process.ExitCode;
+
+        private static void RedirectIOForProcessStartInfo(ProcessStartInfo startInfo)
+        {
             startInfo.UseShellExecute = false;
             startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
             startInfo.RedirectStandardInput = true;
         }
-
-        public int ExitCode => _process.ExitCode;
     }
 }

--- a/eawx-build/Steam/Facepunch.Adapters/FacepunchSteamWorkshopAdapter.cs
+++ b/eawx-build/Steam/Facepunch.Adapters/FacepunchSteamWorkshopAdapter.cs
@@ -5,25 +5,32 @@ using Steamworks;
 using Steamworks.Ugc;
 using static EawXBuild.Steam.Facepunch.Adapters.Utilities;
 
-namespace EawXBuild.Steam.Facepunch.Adapters {
-    public class FacepunchSteamWorkshopAdapter : ISteamWorkshop {
-        public static FacepunchSteamWorkshopAdapter Instance { get; } = new FacepunchSteamWorkshopAdapter();
+namespace EawXBuild.Steam.Facepunch.Adapters
+{
+    public class FacepunchSteamWorkshopAdapter : ISteamWorkshop
+    {
+        private FacepunchSteamWorkshopAdapter()
+        {
+        }
 
-        private FacepunchSteamWorkshopAdapter() { }
+        public static FacepunchSteamWorkshopAdapter Instance { get; } = new FacepunchSteamWorkshopAdapter();
 
         private uint AppId { get; set; }
 
-        public void Init(uint appId) {
+        public void Init(uint appId)
+        {
             SteamClient.Init(appId);
             AppId = appId;
         }
 
-        public void Shutdown() {
+        public void Shutdown()
+        {
             SteamClient.Shutdown();
         }
 
-        public async Task<WorkshopItemPublishResult> PublishNewWorkshopItemAsync(IWorkshopItemChangeSet settings) {
-            var editor = Editor.NewCommunityFile;
+        public async Task<WorkshopItemPublishResult> PublishNewWorkshopItemAsync(IWorkshopItemChangeSet settings)
+        {
+            Editor editor = Editor.NewCommunityFile;
             editor = EditorWithVisibility(settings.Visibility, ref editor)
                 .ForAppId(AppId)
                 .WithTitle(settings.Title)
@@ -32,19 +39,21 @@ namespace EawXBuild.Steam.Facepunch.Adapters {
                 .InLanguage(settings.Language);
             WithTags(settings, ref editor);
 
-            var submitResult = await editor.SubmitAsync();
-            var publishResult = submitResult.Success ? PublishResult.Ok : PublishResult.Failed;
+            Steamworks.Ugc.PublishResult submitResult = await editor.SubmitAsync();
+            PublishResult publishResult = submitResult.Success ? PublishResult.Ok : PublishResult.Failed;
 
             return new WorkshopItemPublishResult(submitResult.FileId, publishResult);
         }
 
-        public async Task<IWorkshopItem?> QueryWorkshopItemByIdAsync(ulong id) {
-            var result = await Item.GetAsync(id);
+        public async Task<IWorkshopItem?> QueryWorkshopItemByIdAsync(ulong id)
+        {
+            Item? result = await Item.GetAsync(id);
 
             return !result.HasValue ? null : new FacepunchWorkshopItemAdapter(result.Value);
         }
 
-        private static void WithTags(IWorkshopItemChangeSet settings, ref Editor editor) {
+        private static void WithTags(IWorkshopItemChangeSet settings, ref Editor editor)
+        {
             foreach (var tag in settings.Tags) editor.WithTag(tag);
         }
     }

--- a/eawx-build/Steam/Facepunch.Adapters/FacepunchWorkshopItemAdapter.cs
+++ b/eawx-build/Steam/Facepunch.Adapters/FacepunchWorkshopItemAdapter.cs
@@ -3,11 +3,14 @@ using System.IO;
 using System.Threading.Tasks;
 using Steamworks.Ugc;
 
-namespace EawXBuild.Steam.Facepunch.Adapters {
-    public class FacepunchWorkshopItemAdapter : IWorkshopItem {
+namespace EawXBuild.Steam.Facepunch.Adapters
+{
+    public class FacepunchWorkshopItemAdapter : IWorkshopItem
+    {
         private Item _item;
 
-        public FacepunchWorkshopItemAdapter(Item item) {
+        public FacepunchWorkshopItemAdapter(Item item)
+        {
             _item = item;
         }
 
@@ -15,8 +18,9 @@ namespace EawXBuild.Steam.Facepunch.Adapters {
         public string Title => _item.Title;
         public string Description { get; set; }
 
-        public async Task<PublishResult> UpdateItemAsync(IWorkshopItemChangeSet settings) {
-            var editor = _item.Edit();
+        public async Task<PublishResult> UpdateItemAsync(IWorkshopItemChangeSet settings)
+        {
+            Editor editor = _item.Edit();
             editor
                 .WithTitle(settings.Title);
             UpdateDescription(settings, ref editor);
@@ -24,24 +28,28 @@ namespace EawXBuild.Steam.Facepunch.Adapters {
             UpdateContent(settings, ref editor);
             UpdateTags(settings, ref editor);
 
-            var result = await editor.SubmitAsync();
+            Steamworks.Ugc.PublishResult result = await editor.SubmitAsync();
 
             return result.Success ? PublishResult.Ok : PublishResult.Failed;
         }
 
-        private static void UpdateDescription(IWorkshopItemChangeSet settings, ref Editor editor) {
+        private static void UpdateDescription(IWorkshopItemChangeSet settings, ref Editor editor)
+        {
             string description = null;
-            if (settings.DescriptionFilePath != null) {
-                var descriptionFile = new FileInfo(settings.DescriptionFilePath);
-                using var streamReader = descriptionFile.OpenText();
+            if (settings.DescriptionFilePath != null)
+            {
+                FileInfo descriptionFile = new FileInfo(settings.DescriptionFilePath);
+                using StreamReader streamReader = descriptionFile.OpenText();
                 description = streamReader.ReadToEnd();
             }
 
             editor.WithDescription(description);
         }
 
-        private static void UpdateVisibility(IWorkshopItemChangeSet settings, ref Editor editor) {
-            switch (settings.Visibility) {
+        private static void UpdateVisibility(IWorkshopItemChangeSet settings, ref Editor editor)
+        {
+            switch (settings.Visibility)
+            {
                 case WorkshopItemVisibility.Public:
                     editor.WithPublicVisibility();
                     break;
@@ -53,13 +61,15 @@ namespace EawXBuild.Steam.Facepunch.Adapters {
             }
         }
 
-        private static void UpdateContent(IWorkshopItemChangeSet settings, ref Editor editor) {
+        private static void UpdateContent(IWorkshopItemChangeSet settings, ref Editor editor)
+        {
             if (settings.ItemFolderPath != null)
                 editor.WithContent(settings.ItemFolderPath);
         }
 
-        private static void UpdateTags(IWorkshopItemChangeSet settings, ref Editor editor) {
-            foreach (var tag in settings.Tags) editor.WithTag(tag);
+        private static void UpdateTags(IWorkshopItemChangeSet settings, ref Editor editor)
+        {
+            foreach (string tag in settings.Tags) editor.WithTag(tag);
         }
     }
 }

--- a/eawx-build/Steam/Facepunch.Adapters/Utilities.cs
+++ b/eawx-build/Steam/Facepunch.Adapters/Utilities.cs
@@ -1,10 +1,14 @@
 using System;
 using Steamworks.Ugc;
 
-namespace EawXBuild.Steam.Facepunch.Adapters {
-    public static class Utilities {
-        public static ref Editor EditorWithVisibility(WorkshopItemVisibility visibility, ref Editor editor) {
-            editor = visibility switch {
+namespace EawXBuild.Steam.Facepunch.Adapters
+{
+    public static class Utilities
+    {
+        public static ref Editor EditorWithVisibility(WorkshopItemVisibility visibility, ref Editor editor)
+        {
+            editor = visibility switch
+            {
                 WorkshopItemVisibility.Private => editor.WithPrivateVisibility(),
                 WorkshopItemVisibility.Public => editor.WithPublicVisibility(),
                 _ => throw new ArgumentOutOfRangeException()

--- a/eawx-build/Steam/Facepunch.Adapters/WorkshopItemNotFoundException.cs
+++ b/eawx-build/Steam/Facepunch.Adapters/WorkshopItemNotFoundException.cs
@@ -1,8 +1,12 @@
 using System;
 
-namespace EawXBuild.Steam.Facepunch.Adapters {
+namespace EawXBuild.Steam.Facepunch.Adapters
+{
     [Serializable]
-    public class WorkshopItemNotFoundException : Exception {
-        public WorkshopItemNotFoundException(string message) : base(message) { }
+    public class WorkshopItemNotFoundException : Exception
+    {
+        public WorkshopItemNotFoundException(string message) : base(message)
+        {
+        }
     }
 }

--- a/eawx-build/Steam/IPublishedWorkshopItem.cs
+++ b/eawx-build/Steam/IPublishedWorkshopItem.cs
@@ -1,5 +1,7 @@
-namespace EawXBuild.Steam {
-    public class PublishedWorkshopItem {
+namespace EawXBuild.Steam
+{
+    public class PublishedWorkshopItem
+    {
         public PublishResult Result { get; }
 
         public IWorkshopItem Item { get; }

--- a/eawx-build/Steam/ISteamWorkshop.cs
+++ b/eawx-build/Steam/ISteamWorkshop.cs
@@ -1,7 +1,9 @@
 using System.Threading.Tasks;
 
-namespace EawXBuild.Steam {
-    public interface ISteamWorkshop {
+namespace EawXBuild.Steam
+{
+    public interface ISteamWorkshop
+    {
         void Init(uint appId);
 
         void Shutdown();

--- a/eawx-build/Steam/IWorkshopItem.cs
+++ b/eawx-build/Steam/IWorkshopItem.cs
@@ -1,7 +1,9 @@
 using System.Threading.Tasks;
 
-namespace EawXBuild.Steam {
-    public interface IWorkshopItem {
+namespace EawXBuild.Steam
+{
+    public interface IWorkshopItem
+    {
         public ulong ItemId { get; }
         string Title { get; }
         string Description { get; }

--- a/eawx-build/Steam/IWorkshopItemChangeSet.cs
+++ b/eawx-build/Steam/IWorkshopItemChangeSet.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 
-namespace EawXBuild.Steam {
-    public interface IWorkshopItemChangeSet {
+namespace EawXBuild.Steam
+{
+    public interface IWorkshopItemChangeSet
+    {
         public string Language { get; set; }
 
         public string Title { get; set; }

--- a/eawx-build/Steam/PublishResult.cs
+++ b/eawx-build/Steam/PublishResult.cs
@@ -1,5 +1,7 @@
-namespace EawXBuild.Steam {
-    public enum PublishResult {
+namespace EawXBuild.Steam
+{
+    public enum PublishResult
+    {
         Ok,
         Failed
     }

--- a/eawx-build/Steam/WorkshopItemChangeSet.cs
+++ b/eawx-build/Steam/WorkshopItemChangeSet.cs
@@ -4,11 +4,14 @@ using System.IO;
 using System.IO.Abstractions;
 using EawXBuild.Exceptions;
 
-namespace EawXBuild.Steam {
-    public class WorkshopItemChangeSet : IWorkshopItemChangeSet {
+namespace EawXBuild.Steam
+{
+    public class WorkshopItemChangeSet : IWorkshopItemChangeSet
+    {
         private readonly IFileSystem _fileSystem;
 
-        public WorkshopItemChangeSet(IFileSystem fileSystem) {
+        public WorkshopItemChangeSet(IFileSystem fileSystem)
+        {
             _fileSystem = fileSystem;
         }
 
@@ -20,39 +23,44 @@ namespace EawXBuild.Steam {
 
         public HashSet<string> Tags { get; set; }
 
-        public string GetDescriptionTextFromFile() {
+        public string GetDescriptionTextFromFile()
+        {
             if (DescriptionFilePath == null) return string.Empty;
-            var fileInfo = _fileSystem.FileInfo.FromFileName(DescriptionFilePath);
-            using var reader = fileInfo.OpenText();
+            IFileInfo fileInfo = _fileSystem.FileInfo.FromFileName(DescriptionFilePath);
+            using StreamReader reader = fileInfo.OpenText();
 
             return reader.ReadToEnd();
         }
 
-        public (bool isValid, Exception exception) IsValidChangeSet() {
+        public (bool isValid, Exception exception) IsValidChangeSet()
+        {
             if (Title == null) return (false, new InvalidOperationException("No title set"));
 
-            var result = ValidateItemFolderPath();
+            (bool isValid, Exception exception) result = ValidateItemFolderPath();
             return !result.isValid ? result : ValidateDescriptionFilePath();
         }
 
-        private (bool isValid, Exception exception) ValidateItemFolderPath() {
+        private (bool isValid, Exception exception) ValidateItemFolderPath()
+        {
             if (ItemFolderPath == null)
                 return (false, new InvalidOperationException("No item folder set"));
 
             if (!_fileSystem.Directory.Exists(ItemFolderPath))
                 return (false, new DirectoryNotFoundException());
 
-            var result = ValidateRelativePath(ItemFolderPath);
+            (bool isValid, Exception exception) result = ValidateRelativePath(ItemFolderPath);
             return !result.isValid ? result : (true, null);
         }
 
-        private (bool isValid, Exception exception) ValidateRelativePath(string path) {
+        private (bool isValid, Exception exception) ValidateRelativePath(string path)
+        {
             return _fileSystem.Path.IsPathRooted(path)
                 ? (false, new NoRelativePathException(path))
                 : (true, null);
         }
 
-        private (bool isValid, Exception exception) ValidateDescriptionFilePath() {
+        private (bool isValid, Exception exception) ValidateDescriptionFilePath()
+        {
             if (DescriptionFilePath == null) return (true, null);
             if (!_fileSystem.File.Exists(DescriptionFilePath)) return (false, new FileNotFoundException());
             (bool isRelativePath, Exception exception) result = ValidateRelativePath(DescriptionFilePath);

--- a/eawx-build/Steam/WorkshopItemPublishResult.cs
+++ b/eawx-build/Steam/WorkshopItemPublishResult.cs
@@ -1,6 +1,9 @@
-namespace EawXBuild.Steam {
-    public class WorkshopItemPublishResult {
-        public WorkshopItemPublishResult(ulong itemId, PublishResult result) {
+namespace EawXBuild.Steam
+{
+    public class WorkshopItemPublishResult
+    {
+        public WorkshopItemPublishResult(ulong itemId, PublishResult result)
+        {
             ItemId = itemId;
             Result = result;
         }

--- a/eawx-build/Steam/WorkshopItemVisibility.cs
+++ b/eawx-build/Steam/WorkshopItemVisibility.cs
@@ -1,5 +1,7 @@
-namespace EawXBuild.Steam {
-    public enum WorkshopItemVisibility {
+namespace EawXBuild.Steam
+{
+    public enum WorkshopItemVisibility
+    {
         Private,
         Public
     }

--- a/eawx-build/Tasks/CleanTask.cs
+++ b/eawx-build/Tasks/CleanTask.cs
@@ -2,11 +2,14 @@ using System.IO.Abstractions;
 using EawXBuild.Core;
 using EawXBuild.Exceptions;
 
-namespace EawXBuild.Tasks {
-    public class CleanTask : ITask {
+namespace EawXBuild.Tasks
+{
+    public class CleanTask : ITask
+    {
         private readonly IFileSystem fileSystem;
 
-        public CleanTask(IFileSystem fileSystem = null) {
+        public CleanTask(IFileSystem fileSystem = null)
+        {
             this.fileSystem = fileSystem ?? new FileSystem();
         }
 
@@ -15,7 +18,8 @@ namespace EawXBuild.Tasks {
         public string Id { get; set; }
         public string Name { get; set; }
 
-        public void Run() {
+        public void Run()
+        {
             if (fileSystem.Path.IsPathRooted(Path)) throw new NoRelativePathException(Path);
             if (fileSystem.Directory.Exists(Path)) fileSystem.Directory.Delete(Path, true);
             else fileSystem.File.Delete(Path);

--- a/eawx-build/Tasks/CopyPolicy.cs
+++ b/eawx-build/Tasks/CopyPolicy.cs
@@ -1,8 +1,11 @@
 using System.IO.Abstractions;
 
-namespace EawXBuild.Tasks {
-    public class CopyPolicy : ICopyPolicy {
-        public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite) {
+namespace EawXBuild.Tasks
+{
+    public class CopyPolicy : ICopyPolicy
+    {
+        public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite)
+        {
             source.CopyTo(target.FullName, overwrite);
         }
     }

--- a/eawx-build/Tasks/CopyTask.cs
+++ b/eawx-build/Tasks/CopyTask.cs
@@ -2,12 +2,15 @@ using System.IO.Abstractions;
 using EawXBuild.Core;
 using EawXBuild.Exceptions;
 
-namespace EawXBuild.Tasks {
-    public class CopyTask : ITask {
-        private readonly IFileSystem _fileSystem;
+namespace EawXBuild.Tasks
+{
+    public class CopyTask : ITask
+    {
         private readonly ICopyPolicy _copyPolicy;
+        private readonly IFileSystem _fileSystem;
 
-        public CopyTask(ICopyPolicy copyPolicy, IFileSystem fileSystem = null) {
+        public CopyTask(ICopyPolicy copyPolicy, IFileSystem fileSystem = null)
+        {
             _fileSystem = fileSystem ?? new FileSystem();
             _copyPolicy = copyPolicy;
             Recursive = true;
@@ -24,30 +27,34 @@ namespace EawXBuild.Tasks {
         public string Id { get; set; }
         public string Name { get; set; }
 
-        public void Run() {
+        public void Run()
+        {
             CheckRelativePaths();
 
-            var directory = _fileSystem.DirectoryInfo.FromDirectoryName(Source);
-            var sourceFile = _fileSystem.FileInfo.FromFileName(Source);
+            IDirectoryInfo directory = _fileSystem.DirectoryInfo.FromDirectoryName(Source);
+            IFileInfo sourceFile = _fileSystem.FileInfo.FromFileName(Source);
 
             if (directory.Exists) CreateDestDirectoryAndCopySourceDirectory(directory);
             else if (sourceFile.Exists) CopySingleFile(sourceFile, Destination);
             else throw new NoSuchFileSystemObjectException(Source);
         }
 
-        private void CheckRelativePaths() {
-            var path = _fileSystem.Path;
+        private void CheckRelativePaths()
+        {
+            IPath path = _fileSystem.Path;
             if (path.IsPathRooted(Source)) throw new NoRelativePathException(Source);
             if (path.IsPathRooted(Destination)) throw new NoRelativePathException(Source);
         }
 
-        private void CreateDestDirectoryAndCopySourceDirectory(IDirectoryInfo directory) {
-            var destinationDirectory = _fileSystem.Directory.CreateDirectory(Destination);
+        private void CreateDestDirectoryAndCopySourceDirectory(IDirectoryInfo directory)
+        {
+            IDirectoryInfo destinationDirectory = _fileSystem.Directory.CreateDirectory(Destination);
             CopyDirectory(directory, destinationDirectory);
         }
 
-        private void CopySingleFile(IFileInfo sourceFile, string destFilePath) {
-            var destFile = _fileSystem.FileInfo.FromFileName(destFilePath);
+        private void CopySingleFile(IFileInfo sourceFile, string destFilePath)
+        {
+            IFileInfo destFile = _fileSystem.FileInfo.FromFileName(destFilePath);
             if (!destFile.Directory.Exists)
                 destFile.Directory.Create();
 
@@ -57,25 +64,31 @@ namespace EawXBuild.Tasks {
             _copyPolicy.CopyTo(sourceFile, destFile, true);
         }
 
-        private void CopyDirectory(IDirectoryInfo sourceDirectory, IDirectoryInfo destinationDirectory) {
+        private void CopyDirectory(IDirectoryInfo sourceDirectory, IDirectoryInfo destinationDirectory)
+        {
             CopyFilesFromDirectory(sourceDirectory, destinationDirectory);
             if (!Recursive) return;
 
             CopySubDirectories(sourceDirectory, destinationDirectory);
         }
 
-        private void CopyFilesFromDirectory(IDirectoryInfo sourceDirectory, IDirectoryInfo destinationDirectory) {
-            var sourceFiles = FilePattern != null ? sourceDirectory.GetFiles(FilePattern) : sourceDirectory.GetFiles();
-            foreach (var sourceFile in sourceFiles) {
-                var destFileName = _fileSystem.Path.Combine(destinationDirectory.FullName, sourceFile.Name);
+        private void CopyFilesFromDirectory(IDirectoryInfo sourceDirectory, IDirectoryInfo destinationDirectory)
+        {
+            IFileInfo[] sourceFiles =
+                FilePattern != null ? sourceDirectory.GetFiles(FilePattern) : sourceDirectory.GetFiles();
+            foreach (IFileInfo sourceFile in sourceFiles)
+            {
+                string destFileName = _fileSystem.Path.Combine(destinationDirectory.FullName, sourceFile.Name);
                 CopySingleFile(sourceFile, destFileName);
             }
         }
 
-        private void CopySubDirectories(IDirectoryInfo sourceDirectory, IDirectoryInfo destinationDirectory) {
-            var subDirectories = sourceDirectory.GetDirectories();
-            foreach (var subDirectory in subDirectories) {
-                var destSubDirectory = destinationDirectory.CreateSubdirectory(subDirectory.Name);
+        private void CopySubDirectories(IDirectoryInfo sourceDirectory, IDirectoryInfo destinationDirectory)
+        {
+            IDirectoryInfo[] subDirectories = sourceDirectory.GetDirectories();
+            foreach (IDirectoryInfo subDirectory in subDirectories)
+            {
+                IDirectoryInfo destSubDirectory = destinationDirectory.CreateSubdirectory(subDirectory.Name);
                 CopyDirectory(subDirectory, destSubDirectory);
             }
         }

--- a/eawx-build/Tasks/ICopyPolicy.cs
+++ b/eawx-build/Tasks/ICopyPolicy.cs
@@ -1,7 +1,9 @@
 using System.IO.Abstractions;
 
-namespace EawXBuild.Tasks {
-    public interface ICopyPolicy {
+namespace EawXBuild.Tasks
+{
+    public interface ICopyPolicy
+    {
         public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite);
     }
 }

--- a/eawx-build/Tasks/LinkCopyPolicy.cs
+++ b/eawx-build/Tasks/LinkCopyPolicy.cs
@@ -1,15 +1,19 @@
 using System.IO.Abstractions;
 using EawXBuild.Native;
 
-namespace EawXBuild.Tasks {
-    public class LinkCopyPolicy : ICopyPolicy {
+namespace EawXBuild.Tasks
+{
+    public class LinkCopyPolicy : ICopyPolicy
+    {
         private readonly IFileLinker _fileLinker;
 
-        public LinkCopyPolicy(IFileLinker fileLinker) {
+        public LinkCopyPolicy(IFileLinker fileLinker)
+        {
             _fileLinker = fileLinker;
         }
 
-        public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite) {
+        public void CopyTo(IFileInfo source, IFileInfo target, bool overwrite)
+        {
             if (target.Exists && !overwrite) return;
             _fileLinker.CreateLink(source.FullName, target.FullName);
         }

--- a/eawx-build/Tasks/RunProcessTask.cs
+++ b/eawx-build/Tasks/RunProcessTask.cs
@@ -4,22 +4,32 @@ using EawXBuild.Core;
 using EawXBuild.Exceptions;
 using EawXBuild.Services.Process;
 
-namespace EawXBuild.Tasks {
-    public class RunProcessTask : ITask {
-        private readonly IProcessRunner _runner;
+namespace EawXBuild.Tasks
+{
+    public class RunProcessTask : ITask
+    {
         private readonly IFileSystem _filesystem;
+        private readonly IProcessRunner _runner;
 
-        public RunProcessTask(IProcessRunner runner, IFileSystem filesystem = null) {
+        public RunProcessTask(IProcessRunner runner, IFileSystem filesystem = null)
+        {
             _runner = runner;
             _filesystem = filesystem ?? new FileSystem();
         }
 
+        public string ExecutablePath { get; set; }
+        public string Arguments { get; set; }
+        public string WorkingDirectory { get; set; } = System.Environment.CurrentDirectory;
+        public bool AllowedToFail { get; set; }
+
         public string Id { get; set; }
         public string Name { get; set; }
 
-        public void Run() {
+        public void Run()
+        {
             if (_filesystem.Path.IsPathRooted(ExecutablePath)) throw new NoRelativePathException(ExecutablePath);
-            _runner.Start(new ProcessStartInfo {
+            _runner.Start(new ProcessStartInfo
+            {
                 FileName = ExecutablePath,
                 Arguments = Arguments,
                 WorkingDirectory = WorkingDirectory
@@ -28,10 +38,5 @@ namespace EawXBuild.Tasks {
             _runner.WaitForExit();
             if (!AllowedToFail && _runner.ExitCode != 0) throw new ProcessFailedException();
         }
-
-        public string ExecutablePath { get; set; }
-        public string Arguments { get; set; }
-        public string WorkingDirectory { get; set; } = System.Environment.CurrentDirectory;
-        public bool AllowedToFail { get; set; }
     }
 }

--- a/eawx-build/Tasks/Steam/CreateSteamWorkshopItemTask.cs
+++ b/eawx-build/Tasks/Steam/CreateSteamWorkshopItemTask.cs
@@ -1,18 +1,23 @@
+using System.Threading.Tasks;
 using EawXBuild.Exceptions;
 using EawXBuild.Steam;
 
-namespace EawXBuild.Tasks.Steam {
-    public class CreateSteamWorkshopItemTask : SteamWorkshopTask {
+namespace EawXBuild.Tasks.Steam
+{
+    public class CreateSteamWorkshopItemTask : SteamWorkshopTask
+    {
         private readonly ISteamWorkshop _workshop;
 
-        public CreateSteamWorkshopItemTask(ISteamWorkshop workshop) {
+        public CreateSteamWorkshopItemTask(ISteamWorkshop workshop)
+        {
             _workshop = workshop;
         }
 
-        protected override void PublishToWorkshop() {
+        protected override void PublishToWorkshop()
+        {
             _workshop.Init(AppId);
-            var publishTask = _workshop.PublishNewWorkshopItemAsync(ChangeSet);
-            var publishResult = publishTask.Result;
+            Task<WorkshopItemPublishResult> publishTask = _workshop.PublishNewWorkshopItemAsync(ChangeSet);
+            WorkshopItemPublishResult publishResult = publishTask.Result;
             _workshop.Shutdown();
             if (publishResult.Result is PublishResult.Failed)
                 throw new ProcessFailedException("Failed to publish to Steam Workshop");

--- a/eawx-build/Tasks/Steam/SteamWorkshopTask.cs
+++ b/eawx-build/Tasks/Steam/SteamWorkshopTask.cs
@@ -2,29 +2,33 @@ using System;
 using EawXBuild.Core;
 using EawXBuild.Steam;
 
-namespace EawXBuild.Tasks.Steam {
-    public abstract class SteamWorkshopTask : ITask {
+namespace EawXBuild.Tasks.Steam
+{
+    public abstract class SteamWorkshopTask : ITask
+    {
+        public uint AppId { get; set; }
+
+        public IWorkshopItemChangeSet ChangeSet { get; set; }
         public string Id { get; set; }
 
         public string Name { get; set; }
 
-        public uint AppId { get; set; }
-
-        public IWorkshopItemChangeSet ChangeSet { get; set; }
-
-        public void Run() {
+        public void Run()
+        {
             ValidateAppId();
             ValidateChangeSet();
             PublishToWorkshop();
         }
 
-        private void ValidateAppId() {
+        private void ValidateAppId()
+        {
             if (AppId == 0) throw new InvalidOperationException("No AppId set");
         }
 
-        private void ValidateChangeSet() {
+        private void ValidateChangeSet()
+        {
             if (ChangeSet == null) throw new InvalidOperationException("No change set given");
-            var (isValid, exception) = ChangeSet.IsValidChangeSet();
+            (bool isValid, Exception exception) = ChangeSet.IsValidChangeSet();
             if (!isValid) throw exception;
 
             ChangeSet.Language ??= "English";

--- a/eawx-build/Tasks/Steam/UpdateSteamWorkshopItemTask.cs
+++ b/eawx-build/Tasks/Steam/UpdateSteamWorkshopItemTask.cs
@@ -1,46 +1,56 @@
 using System;
+using System.Threading.Tasks;
 using EawXBuild.Exceptions;
 using EawXBuild.Steam;
 using EawXBuild.Steam.Facepunch.Adapters;
 
-namespace EawXBuild.Tasks.Steam {
-    public class UpdateSteamWorkshopItemTask : SteamWorkshopTask {
+namespace EawXBuild.Tasks.Steam
+{
+    public class UpdateSteamWorkshopItemTask : SteamWorkshopTask
+    {
         private readonly ISteamWorkshop _workshop;
 
-        public UpdateSteamWorkshopItemTask(ISteamWorkshop workshop) {
+        public UpdateSteamWorkshopItemTask(ISteamWorkshop workshop)
+        {
             _workshop = workshop;
         }
 
         public ulong ItemId { get; set; }
 
-        protected override void PublishToWorkshop() {
+        protected override void PublishToWorkshop()
+        {
             ValidateItemId();
             _workshop.Init(AppId);
-            try {
-                var item = TryQueryWorkshopItemOrThrow();
+            try
+            {
+                IWorkshopItem item = TryQueryWorkshopItemOrThrow();
                 TryUpdateItemOrThrow(item);
             }
-            finally {
+            finally
+            {
                 _workshop.Shutdown();
             }
         }
 
-        private IWorkshopItem TryQueryWorkshopItemOrThrow() {
-            var queryItemTask = _workshop.QueryWorkshopItemByIdAsync(ItemId);
-            var item = queryItemTask.Result;
+        private IWorkshopItem TryQueryWorkshopItemOrThrow()
+        {
+            Task<IWorkshopItem> queryItemTask = _workshop.QueryWorkshopItemByIdAsync(ItemId);
+            IWorkshopItem item = queryItemTask.Result;
             if (item == null)
                 throw new WorkshopItemNotFoundException("No workshop item with given Id");
 
             return item;
         }
 
-        private void TryUpdateItemOrThrow(IWorkshopItem item) {
-            var updateTask = item.UpdateItemAsync(ChangeSet);
+        private void TryUpdateItemOrThrow(IWorkshopItem item)
+        {
+            Task<PublishResult> updateTask = item.UpdateItemAsync(ChangeSet);
             if (updateTask.Result is PublishResult.Failed)
                 throw new ProcessFailedException("Workshop item update failed");
         }
 
-        private void ValidateItemId() {
+        private void ValidateItemId()
+        {
             if (ItemId == 0) throw new InvalidOperationException("No ItemId set");
         }
     }

--- a/eawx-build/eawx-build.csproj
+++ b/eawx-build/eawx-build.csproj
@@ -1,29 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <RootNamespace>EawXBuild</RootNamespace>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <ProjectGuid>{F680D892-58D2-40B5-B326-7A9225770903}</ProjectGuid>
-        <Title>EaW CI</Title>
-        <Authors>Sven Marcus &amp; Lukas Grünwald</Authors>
-        <Copyright>Sven Marcus &amp; Lukas Grünwald</Copyright>
-        <PackageVersion>0.1.0</PackageVersion>
-        <AssemblyVersion>0.1.0.*</AssemblyVersion>
-        <FileVersion>0.1.0</FileVersion>
-        <AssemblyName>eaw-ci</AssemblyName>
-        <IsPackable>false</IsPackable>
-        <PackageId>eaw-ci</PackageId>
-        <Product>eaw-ci</Product>
-        <Version>0.1.0</Version>
-        <RepositoryUrl>https://github.com/AlamoEngine-Tools/eaw-ci</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <PackageProjectUrl>https://github.com/AlamoEngine-Tools/eaw-ci</PackageProjectUrl>
-        <PackageLicenseFile>LICENSE</PackageLicenseFile>
-        <StartupObject>EawXBuild.Host</StartupObject>
-        <Deterministic>false</Deterministic>
-    </PropertyGroup>
-
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>EawXBuild</RootNamespace>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <ProjectGuid>{F680D892-58D2-40B5-B326-7A9225770903}</ProjectGuid>
+    <Title>EaW CI</Title>
+    <Authors>Sven Marcus &amp; Lukas Grünwald</Authors>
+    <Copyright>Copyright © 2021 Sven Marcus &amp; Lukas Grünwald</Copyright>
+    <PackageVersion>0.1.0</PackageVersion>
+    <AssemblyVersion>0.1.0.*</AssemblyVersion>
+    <InformationalVersion>0.1.0</InformationalVersion>
+    <FileVersion>0.1.0</FileVersion>
+    <AssemblyName>eaw-ci</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <PackageId>eaw-ci</PackageId>
+    <Product>eaw-ci</Product>
+    <Version>0.1.0</Version>
+    <RepositoryUrl>https://github.com/AlamoEngine-Tools/eaw-ci</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/AlamoEngine-Tools/eaw-ci</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <StartupObject>EawXBuild.Host</StartupObject>
+    <Deterministic>false</Deterministic>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
@@ -34,43 +33,45 @@
     <PackageReference Include="semver" Version="2.0.6" />
     <PackageReference Include="System.IO.Abstractions" Version="13.2.29" />
   </ItemGroup>
-
-    <ItemGroup>
-        <None Remove="Configuration\v1\eaw-ci.xsd" />
-        <None Include="..\LICENSE">
-            <Pack>True</Pack>
-        </None>
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="..\.editorconfig" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <EmbeddedResource Include="Configuration\Xml\v1\eaw-ci.xsd" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Reference Include="Facepunch.Steamworks.Posix, Culture=neutral, PublicKeyToken=null" Condition="$([MSBuild]::IsOsPlatform('Linux'))">
-            <HintPath>Steam\Facepunch.Steamworks\2.3.2\Facepunch.Steamworks.Posix.dll</HintPath>
-        </Reference>
-        <Reference Include="Facepunch.Steamworks.Posix, Culture=neutral, PublicKeyToken=null" Condition="$([MSBuild]::IsOsPlatform('OSX'))">
-            <HintPath>Steam\Facepunch.Steamworks\2.3.2\Facepunch.Steamworks.Posix.dll</HintPath>
-        </Reference>
-        <Reference Include="Facepunch.Steamworks.Win64, Culture=neutral, PublicKeyToken=null" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-            <HintPath>Steam\Facepunch.Steamworks\2.3.2\Facepunch.Steamworks.Win64.dll</HintPath>
-        </Reference>
-    </ItemGroup>
-
-    <Target Name="CopyLibSteam" AfterTargets="AfterBuild">
-        <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\libsteam_api.so" DestinationFolder="$(OutDir)" />
-        <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\libsteam_api.bundle" DestinationFolder="$(OutDir)" />
-        <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\steam_api64.dll" DestinationFolder="$(OutDir)" />
-    </Target>
-    
-    <Target Name="CopyLibSteamForPublish" AfterTargets="Publish">
-        <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\libsteam_api.so" DestinationFolder="$(PublishDir)" />
-        <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\libsteam_api.bundle" DestinationFolder="$(PublishDir)" />
-        <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\steam_api64.dll" DestinationFolder="$(PublishDir)" />
-    </Target>
+  <PropertyGroup>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Remove="Configuration\v1\eaw-ci.xsd" />
+    <None Include="..\LICENSE">
+      <Pack>True</Pack>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\.editorconfig" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Configuration\Xml\v1\eaw-ci.xsd" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Facepunch.Steamworks.Posix, Culture=neutral, PublicKeyToken=null" Condition="$([MSBuild]::IsOsPlatform('Linux'))">
+      <HintPath>Steam\Facepunch.Steamworks\2.3.2\Facepunch.Steamworks.Posix.dll</HintPath>
+    </Reference>
+    <Reference Include="Facepunch.Steamworks.Posix, Culture=neutral, PublicKeyToken=null" Condition="$([MSBuild]::IsOsPlatform('OSX'))">
+      <HintPath>Steam\Facepunch.Steamworks\2.3.2\Facepunch.Steamworks.Posix.dll</HintPath>
+    </Reference>
+    <Reference Include="Facepunch.Steamworks.Win64, Culture=neutral, PublicKeyToken=null" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
+      <HintPath>Steam\Facepunch.Steamworks\2.3.2\Facepunch.Steamworks.Win64.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Target Name="CopyLibSteam" AfterTargets="AfterBuild">
+    <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\libsteam_api.so" DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\libsteam_api.bundle" DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\steam_api64.dll" DestinationFolder="$(OutDir)" />
+  </Target>    
+  <Target Name="CopyLibSteamForPublish" AfterTargets="Publish">
+    <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\libsteam_api.so" DestinationFolder="$(PublishDir)" />
+    <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\libsteam_api.bundle" DestinationFolder="$(PublishDir)" />
+    <Copy SourceFiles="Steam\Facepunch.Steamworks\2.3.2\SteamAPI\steam_api64.dll" DestinationFolder="$(PublishDir)" />
+  </Target>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>eawx-build-test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
- If `null` is passed as ILoggerFactory, the `ILogger<T>` is created via the `NullLoggerFactory`.
- The `IIOService` has been renamed to the more accurate  `IIOHelperService`
- Adds native `InternalsVisibleTo` support. The attribute is no longer necessary.
- Adds full support for coverage calculation.